### PR TITLE
fix: support tmux cross-session jumps

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -283,14 +283,20 @@ impl App {
             };
 
             if is_descendant_of(target_pid, pane_pid) {
-                let _ = std::process::Command::new("tmux")
-                    .args(["select-pane", "-t", pane_target])
-                    .status();
+                // Switch tmux client to the target session (needed for cross-session jumps)
+                if let Some(session_name) = pane_target.split(':').next() {
+                    let _ = std::process::Command::new("tmux")
+                        .args(["switch-client", "-t", session_name])
+                        .status();
+                }
                 if let Some(window) = pane_target.split('.').next() {
                     let _ = std::process::Command::new("tmux")
                         .args(["select-window", "-t", window])
                         .status();
                 }
+                let _ = std::process::Command::new("tmux")
+                    .args(["select-pane", "-t", pane_target])
+                    .status();
                 return None; // success
             }
         }


### PR DESCRIPTION
Previously, pressing Enter to jump to a session only worked within the
  same tmux session — select-pane/select-window target the right pane but don't switch the client to a different tmux session.

  This adds a switch-client call before select-window/select-pane so cross-session jumps work correctly.

  ## Changes
  - Add \`tmux switch-client -t <session>\` before window/pane selection
  - Reorder: switch-client → select-window → select-pane (session context must be set first)