### PR TITLE
fix: respect CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -18,10 +18,12 @@ pub struct ClaudeCollector {
 
 impl ClaudeCollector {
     pub fn new() -> Self {
-        let home = dirs::home_dir().unwrap_or_default();
+        let base = std::env::var("CLAUDE_CONFIG_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".claude"));
         Self {
-            sessions_dir: home.join(".claude").join("sessions"),
-            projects_dir: home.join(".claude").join("projects"),
+            sessions_dir: base.join("sessions"),
+            projects_dir: base.join("projects"),
             transcript_cache: HashMap::new(),
         }
     }

--- a/src/collector/rate_limit.rs
+++ b/src/collector/rate_limit.rs
@@ -34,7 +34,11 @@ pub fn read_rate_limits() -> Vec<RateLimitInfo> {
     let mut results = Vec::new();
 
     // Claude Code: read from StatusLine hook output file
-    if let Some(claude_dir) = dirs::home_dir().map(|h| h.join(".claude")) {
+    if let Some(claude_dir) = std::env::var("CLAUDE_CONFIG_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".claude")))
+    {
         let path = claude_dir.join(CLAUDE_RATE_FILE);
         if let Some(info) = read_rate_file(&path, "claude") {
             results.push(info);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -19,14 +19,16 @@ if fh:
 sd = rl.get('seven_day')
 if sd:
     out['seven_day'] = {'used_percentage': sd.get('used_percentage', 0), 'resets_at': sd.get('resets_at', 0)}
-home = os.path.expanduser('~')
-with open(os.path.join(home, '.claude', 'abtop-rate-limits.json'), 'w') as f:
+config_dir = os.environ.get('CLAUDE_CONFIG_DIR', os.path.join(os.path.expanduser('~'), '.claude'))
+with open(os.path.join(config_dir, 'abtop-rate-limits.json'), 'w') as f:
     json.dump(out, f)
 " "$INPUT" 2>/dev/null
 "#;
 
 fn claude_dir() -> PathBuf {
-    dirs::home_dir().unwrap_or_default().join(".claude")
+    std::env::var("CLAUDE_CONFIG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".claude"))
 }
 
 fn script_path() -> PathBuf {


### PR DESCRIPTION
## Summary
- Check `CLAUDE_CONFIG_DIR` env var before falling back to `~/.claude` in all path resolution: session/project discovery, rate limit file reading, and `--setup` hook installation
- Also updates the StatusLine Python script to use `CLAUDE_CONFIG_DIR` at runtime

Closes #12

## Test plan
- [ ] Set `CLAUDE_CONFIG_DIR=~/.claude-pro` and verify abtop detects sessions in custom directory
- [ ] Without `CLAUDE_CONFIG_DIR` set, verify default `~/.claude` behavior unchanged
- [ ] Run `CLAUDE_CONFIG_DIR=~/.claude-pro abtop --setup` and verify script/settings written to correct directory