### PR TITLE
fix: add timeout to statusline script to prevent hanging

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 const STATUSLINE_SCRIPT: &str = r#"#!/bin/bash
 # abtop StatusLine hook — writes rate limit data for abtop to read.
 # Installed by: abtop --setup
-INPUT=$(cat)
+INPUT=$(timeout 5 cat)
 python3 -c "
 import sys, json, time, os
 data = json.loads(sys.argv[1])


### PR DESCRIPTION
## Summary
- Fix `abtop-statusline.sh` hanging indefinitely when stdin is not properly closed
- Replace `cat` with `timeout 5 cat` so the script aborts after 5 seconds

Fixes #15

## Test plan
- [ ] Run `abtop --setup` and verify the script is generated correctly
- [ ] Confirm rate limit data is written to `abtop-rate-limits.json` during a Claude Code session
- [ ] Verify the script exits after 5 seconds when no stdin is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)