### PR TITLE
feat: extract and display Codex /effort setting

### DIFF
--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -274,6 +274,7 @@ impl ClaudeCollector {
             started_at: sf.started_at,
             status,
             model,
+            effort: String::new(),
             context_percent,
             total_input_tokens: total_input,
             total_output_tokens: total_output,

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -265,6 +265,11 @@ impl ClaudeCollector {
         let memory_dir = project_dir.join("memory");
         let (mem_file_count, mem_line_count) = Self::collect_memory_status(&memory_dir);
 
+        // Effort level (persistent `effortLevel` from settings files).
+        // Note: the `/effort` slash command is session-scoped and does NOT persist,
+        // so this only reflects settings.json — not live in-session overrides.
+        let effort = read_effort_level(&sf.cwd);
+
         Some(AgentSession {
             agent_cli: "claude",
             pid: sf.pid,
@@ -274,7 +279,7 @@ impl ClaudeCollector {
             started_at: sf.started_at,
             status,
             model,
-            effort: String::new(),
+            effort,
             context_percent,
             total_input_tokens: total_input,
             total_output_tokens: total_output,
@@ -759,6 +764,54 @@ fn context_window_for_model(model: &str, last_context_tokens: u64) -> u64 {
     }
 }
 
+/// Read the persistent `effortLevel` for a Claude Code session.
+///
+/// Precedence (highest wins), matching Claude Code's own resolution order:
+/// 1. `CLAUDE_CODE_EFFORT_LEVEL` env var (abtop's own env — only visible when
+///    set in the user's shell before launching both abtop and claude)
+/// 2. `{cwd}/.claude/settings.local.json`
+/// 3. `{cwd}/.claude/settings.json`
+/// 4. `~/.claude/settings.local.json`
+/// 5. `~/.claude/settings.json`
+///
+/// Returns an empty string when no `effortLevel` is set. This does NOT capture
+/// in-session `/effort` changes — those are ephemeral and not written to disk.
+fn read_effort_level(cwd: &str) -> String {
+    if let Ok(v) = std::env::var("CLAUDE_CODE_EFFORT_LEVEL") {
+        let trimmed = v.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let cwd_path = PathBuf::from(cwd);
+    candidates.push(cwd_path.join(".claude").join("settings.local.json"));
+    candidates.push(cwd_path.join(".claude").join("settings.json"));
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".claude").join("settings.local.json"));
+        candidates.push(home.join(".claude").join("settings.json"));
+    }
+
+    for path in candidates {
+        if let Some(level) = read_effort_from_settings(&path) {
+            return level;
+        }
+    }
+    String::new()
+}
+
+fn read_effort_from_settings(path: &Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    let val: Value = serde_json::from_str(&content).ok()?;
+    let level = val.get("effortLevel")?.as_str()?.trim();
+    if level.is_empty() {
+        None
+    } else {
+        Some(level.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -949,5 +1002,34 @@ mod tests {
         let result = parse_transcript(file.path(), 0);
         assert_eq!(result.version, "2.1.90");
         assert_eq!(result.git_branch, "feat/payments");
+    }
+
+    #[test]
+    fn test_read_effort_from_settings_extracts_value() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, r#"{{"effortLevel":"high","other":true}}"#).unwrap();
+        file.flush().unwrap();
+        assert_eq!(read_effort_from_settings(file.path()).as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn test_read_effort_from_settings_missing_field_returns_none() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, r#"{{"permissions":{{"deny":[]}}}}"#).unwrap();
+        file.flush().unwrap();
+        assert!(read_effort_from_settings(file.path()).is_none());
+    }
+
+    #[test]
+    fn test_read_effort_from_settings_empty_string_returns_none() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, r#"{{"effortLevel":""}}"#).unwrap();
+        file.flush().unwrap();
+        assert!(read_effort_from_settings(file.path()).is_none());
+    }
+
+    #[test]
+    fn test_read_effort_from_settings_nonexistent_file() {
+        assert!(read_effort_from_settings(Path::new("/nonexistent/nowhere.json")).is_none());
     }
 }

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -240,6 +240,7 @@ impl CodexCollector {
             started_at: result.started_at,
             status,
             model: result.model,
+            effort: result.effort,
             context_percent,
             total_input_tokens: result.total_input,
             total_output_tokens: result.total_output,
@@ -335,6 +336,9 @@ struct CodexJSONLResult {
     cwd: String,
     started_at: u64,
     model: String,
+    /// Reasoning effort setting from turn_context: "minimal" | "low" | "medium" | "high".
+    /// Tracks the most recent value — users can change `/effort` mid-session.
+    effort: String,
     version: String,
     git_branch: String,
     context_window: u64,
@@ -372,6 +376,7 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
         cwd: String::new(),
         started_at: 0,
         model: String::from("-"),
+        effort: String::new(),
         version: String::new(),
         git_branch: String::new(),
         context_window: 0,
@@ -554,6 +559,10 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                 if let Some(m) = payload["model"].as_str() {
                     result.model = m.to_string();
                 }
+                // Effort may change mid-session via /effort — always take the latest.
+                if let Some(e) = payload["effort"].as_str() {
+                    result.effort = e.to_string();
+                }
                 if let Some(cw) = payload["model_context_window"].as_u64() {
                     result.context_window = cw;
                 }
@@ -649,6 +658,32 @@ mod tests {
         let result = parse_codex_jsonl(file.path()).unwrap();
         // Bad line skipped, agent_message still counted
         assert_eq!(result.turn_count, 1);
+    }
+
+    #[test]
+    fn test_parse_codex_turn_context_effort() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write_lines(&mut file, &[
+            SESSION_META,
+            r#"{"type":"turn_context","timestamp":"2026-03-28T15:01:00Z","payload":{"cwd":"/home/user/project","model":"gpt-5-codex","effort":"low","summary":"auto"}}"#,
+            // Later turn_context overrides — /effort can change mid-session
+            r#"{"type":"turn_context","timestamp":"2026-03-28T15:02:00Z","payload":{"cwd":"/home/user/project","model":"gpt-5-codex","effort":"high","summary":"auto"}}"#,
+        ]);
+        let result = parse_codex_jsonl(file.path()).unwrap();
+        assert_eq!(result.model, "gpt-5-codex");
+        assert_eq!(result.effort, "high");
+    }
+
+    #[test]
+    fn test_parse_codex_missing_effort_is_empty() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write_lines(&mut file, &[
+            SESSION_META,
+            // turn_context without effort field
+            r#"{"type":"turn_context","timestamp":"2026-03-28T15:01:00Z","payload":{"cwd":"/home/user/project","model":"gpt-5-codex"}}"#,
+        ]);
+        let result = parse_codex_jsonl(file.path()).unwrap();
+        assert_eq!(result.effort, "");
     }
 
     #[test]

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -27,6 +27,7 @@ pub fn populate_demo(app: &mut App) {
             started_at: now - 2 * 3600 * 1000, // 2h ago
             status: SessionStatus::Working,
             model: "claude-opus-4-6".into(),
+            effort: String::new(),
             context_percent: 72.0,
             total_input_tokens: 48_200,
             total_output_tokens: 12_800,
@@ -89,6 +90,7 @@ pub fn populate_demo(app: &mut App) {
             started_at: now - 47 * 60 * 1000, // 47m ago
             status: SessionStatus::Waiting,
             model: "claude-sonnet-4-6".into(),
+            effort: String::new(),
             context_percent: 91.0,
             total_input_tokens: 82_000,
             total_output_tokens: 38_000,
@@ -124,6 +126,7 @@ pub fn populate_demo(app: &mut App) {
             started_at: now - 15 * 60 * 1000, // 15m ago
             status: SessionStatus::Working,
             model: "claude-haiku-4-5".into(),
+            effort: String::new(),
             context_percent: 42.0,
             total_input_tokens: 5_200,
             total_output_tokens: 2_800,
@@ -176,6 +179,7 @@ pub fn populate_demo(app: &mut App) {
             started_at: now - 5 * 60 * 1000, // 5m ago
             status: SessionStatus::Working,
             model: "gpt-5.4".into(),
+            effort: "medium".into(),
             context_percent: 18.0,
             total_input_tokens: 3_100,
             total_output_tokens: 1_400,

--- a/src/model/session.rs
+++ b/src/model/session.rs
@@ -60,6 +60,9 @@ pub struct AgentSession {
     pub started_at: u64,
     pub status: SessionStatus,
     pub model: String,
+    /// Reasoning effort setting (Codex CLI only: "minimal" | "low" | "medium" | "high").
+    /// Empty string when unknown or not applicable.
+    pub effort: String,
     pub context_percent: f64,
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
@@ -138,6 +141,7 @@ mod tests {
             started_at: 0,
             status: SessionStatus::Waiting,
             model: String::new(),
+            effort: String::new(),
             context_percent: 0.0,
             total_input_tokens: input,
             total_output_tokens: output,

--- a/src/ui/sessions.rs
+++ b/src/ui/sessions.rs
@@ -508,12 +508,18 @@ pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &
                     Style::default().fg(mem_color),
                 )));
             }
+            let effort_part = if session.effort.is_empty() {
+                String::new()
+            } else {
+                format!(" · effort: {}", session.effort)
+            };
             footer_lines.push(Line::from(Span::styled(
                 format!(
-                    " {} · {} · {} turns",
+                    " {} · {} · {} turns{}",
                     session.version,
                     session.elapsed_display(),
-                    session.turn_count
+                    session.turn_count,
+                    effort_part,
                 ),
                 Style::default().fg(theme.inactive_fg),
             )));


### PR DESCRIPTION
## Summary
Adds `/effort` level extraction for both Codex CLI and Claude Code sessions, displayed in the session detail footer (`effort: medium`).

**Codex CLI** — parsed from the `turn_context.effort` field in the rollout JSONL. Latest value wins, since users can change `/effort` mid-session.

**Claude Code** — read from the persistent `effortLevel` setting, using Claude Code's own resolution order:
1. `CLAUDE_CODE_EFFORT_LEVEL` env var
2. `{cwd}/.claude/settings.local.json`
3. `{cwd}/.claude/settings.json`
4. `~/.claude/settings.local.json`
5. `~/.claude/settings.json`

### Known limitation (Claude Code)
The `/effort` slash command is session-scoped and does NOT persist to disk, so abtop can only show the **configured** effort level, not live in-session overrides. This is unfortunately a filesystem limitation — there is no transcript field or state file for it.

Closes #31

## Test plan
- [x] `cargo test` — 31 tests pass (6 new: Codex latest-wins + missing field; Claude settings extraction + missing field + empty string + nonexistent file)
- [x] `cargo clippy` clean
- [ ] Run `abtop` against a live Codex session and verify the footer shows the current `/effort`
- [ ] Set `effortLevel` in `~/.claude/settings.json`, run `abtop` against a live Claude session, verify it surfaces
- [ ] Change Codex `/effort` mid-session, confirm the displayed value updates on next tick