### PR TITLE
security: harden against local attack vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"
 chrono = { version = "0.4", features = ["serde"] }
-
-[dev-dependencies]
 tempfile = "3"
 
 # The profile that 'dist' will build with

--- a/src/app.rs
+++ b/src/app.rs
@@ -222,8 +222,22 @@ impl App {
         // Check if we have a pending confirmation for this exact session
         if let Some((idx, ts)) = self.kill_confirm.take() {
             if idx == self.selected && ts.elapsed().as_secs() < 2 {
-                // Confirmed — actually kill
+                // Confirmed — verify PID still runs expected binary before killing
                 let pid = session.pid;
+                let verified = std::process::Command::new("ps")
+                    .args(["-p", &pid.to_string(), "-o", "command="])
+                    .output()
+                    .ok()
+                    .map(|output| {
+                        let cmd = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                        crate::collector::process::cmd_has_binary(&cmd, "claude")
+                            || crate::collector::process::cmd_has_binary(&cmd, "codex")
+                    })
+                    .unwrap_or(false);
+                if !verified {
+                    self.set_status(format!("PID {} is no longer a claude/codex process", pid));
+                    return;
+                }
                 let _ = std::process::Command::new("kill")
                     .args(["-9", &pid.to_string()])
                     .output();
@@ -536,6 +550,9 @@ fn save_summary_cache(summaries: &HashMap<String, String>) {
     let path = cache_path();
     let _ = std::fs::create_dir_all(cache_dir());
     if let Ok(json) = serde_json::to_string(summaries) {
-        let _ = std::fs::write(&path, json);
+        let tmp = path.with_extension("tmp");
+        if std::fs::write(&tmp, &json).is_ok() {
+            let _ = std::fs::rename(&tmp, &path);
+        }
     }
 }

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -3,7 +3,7 @@ use crate::model::{AgentSession, ChildProcess, SessionFile, SessionStatus, SubAg
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
@@ -564,13 +564,17 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
     let mut line_buf = String::new();
     loop {
         line_buf.clear();
-        match reader.read_line(&mut line_buf) {
+        // Bounded read: take(MAX+1) physically caps the allocation. Without
+        // this, a malformed or hostile transcript with an unbounded line
+        // would OOM the process before any length check could fire.
+        match reader.by_ref().take(MAX_LINE_BYTES as u64 + 1).read_line(&mut line_buf) {
             Ok(0) => break,
             Ok(n) => {
-                // Skip oversized lines to prevent OOM from malformed input
-                if line_buf.len() > MAX_LINE_BYTES {
-                    bytes_read += n as u64;
-                    continue;
+                // Cap hit without a newline — malformed/hostile line. Skip
+                // to end of file; we'll re-evaluate when file_identity changes.
+                if line_buf.len() > MAX_LINE_BYTES && !line_buf.ends_with('\n') {
+                    bytes_read = file_len;
+                    break;
                 }
                 let has_newline = line_buf.ends_with('\n');
                 let line = line_buf.trim();

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -19,8 +19,10 @@ pub struct ClaudeCollector {
 impl ClaudeCollector {
     pub fn new() -> Self {
         let base = std::env::var("CLAUDE_CONFIG_DIR")
+            .ok()
             .map(PathBuf::from)
-            .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".claude"));
+            .filter(|p| p.is_dir())
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".claude"));
         Self {
             sessions_dir: base.join("sessions"),
             projects_dir: base.join("projects"),
@@ -38,6 +40,10 @@ impl ClaudeCollector {
         for entry in session_files.flatten() {
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            // Skip symlinks to avoid reading unintended files
+            if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(true) {
                 continue;
             }
 
@@ -63,7 +69,8 @@ impl ClaudeCollector {
         ports: &HashMap<u32, Vec<u16>>,
     ) -> Option<AgentSession> {
         let content = fs::read_to_string(path).ok()?;
-        let sf: SessionFile = serde_json::from_str(&content).ok()?;
+        let mut sf: SessionFile = serde_json::from_str(&content).ok()?;
+        sf.sanitize();
 
         let proc_cmd = process_info.get(&sf.pid).map(|p| p.command.as_str());
         let pid_alive = proc_cmd
@@ -231,7 +238,11 @@ impl ClaudeCollector {
             .get(&sf.pid)
             .cloned()
             .unwrap_or_default();
+        let mut visited = std::collections::HashSet::new();
         while let Some(cpid) = stack.pop() {
+            if !visited.insert(cpid) {
+                continue;
+            }
             if let Some(cproc) = process_info.get(&cpid) {
                 let port = ports.get(&cpid).and_then(|v| v.first().copied());
                 children.push(ChildProcess {
@@ -308,7 +319,7 @@ impl ClaudeCollector {
         // Primary: look up by encoded cwd
         let encoded = encode_cwd_path(cwd);
         let path = self.projects_dir.join(&encoded).join(&jsonl_name);
-        if path.exists() {
+        if path.exists() && !is_symlink(&path) {
             return Some(path);
         }
 
@@ -317,11 +328,14 @@ impl ClaudeCollector {
         // may not match the encoded cwd from the session file.
         if let Ok(entries) = fs::read_dir(&self.projects_dir) {
             for entry in entries.flatten() {
+                if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(true) {
+                    continue;
+                }
                 if !entry.path().is_dir() {
                     continue;
                 }
                 let candidate = entry.path().join(&jsonl_name);
-                if candidate.exists() {
+                if candidate.exists() && !is_symlink(&candidate) {
                     return Some(candidate);
                 }
             }
@@ -342,6 +356,9 @@ impl ClaudeCollector {
         // Collect meta files and their corresponding jsonl files
         let mut meta_files: Vec<PathBuf> = Vec::new();
         for entry in entries.flatten() {
+            if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(true) {
+                continue;
+            }
             let path = entry.path();
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 if name.ends_with(".meta.json") {
@@ -469,6 +486,14 @@ struct TranscriptResult {
     first_assistant_text: String,
 }
 
+/// Check if a path is a symlink without following it.
+/// Defaults to true on error (fail-closed: skip if we can't verify).
+fn is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(true)
+}
+
 /// Get file identity as (inode, mtime_nanos) for detecting file replacement.
 fn file_identity(path: &Path) -> (u64, u64) {
     fs::metadata(path)
@@ -533,6 +558,8 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
         .unwrap_or(std::time::UNIX_EPOCH);
     result.last_activity = mtime;
 
+    const MAX_LINE_BYTES: usize = 10 * 1024 * 1024; // 10 MB
+
     let mut bytes_read = from_offset;
     let mut line_buf = String::new();
     loop {
@@ -540,6 +567,11 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
         match reader.read_line(&mut line_buf) {
             Ok(0) => break,
             Ok(n) => {
+                // Skip oversized lines to prevent OOM from malformed input
+                if line_buf.len() > MAX_LINE_BYTES {
+                    bytes_read += n as u64;
+                    continue;
+                }
                 let has_newline = line_buf.ends_with('\n');
                 let line = line_buf.trim();
                 if line.is_empty() {
@@ -589,8 +621,10 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
                                     if result.last_context_tokens > result.max_context_tokens {
                                         result.max_context_tokens = result.last_context_tokens;
                                     }
-                                    // Track per-turn total tokens for sparkline
-                                    result.token_history.push(inp + out + cr + cc);
+                                    // Track per-turn total tokens for sparkline (cap to prevent OOM)
+                                    if result.token_history.len() < 10_000 {
+                                        result.token_history.push(inp + out + cr + cc);
+                                    }
                                 }
                                 // Extract first assistant text (text blocks only) for summary fallback
                                 if result.first_assistant_text.is_empty() {
@@ -722,10 +756,10 @@ fn extract_tool_arg(tool_use: &Value) -> String {
         if let Some(fp) = input.get("file_path").and_then(|f| f.as_str()) {
             return shorten_path(fp);
         }
-        // Bash: command (first 40 chars)
+        // Bash: command (first 40 chars, redact secrets)
         if let Some(cmd) = input.get("command").and_then(|c| c.as_str()) {
             let short = cmd.lines().next().unwrap_or(cmd);
-            return truncate(short, 40);
+            return redact_secrets(&truncate(short, 40));
         }
         // Grep/Glob: pattern
         if let Some(pat) = input.get("pattern").and_then(|p| p.as_str()) {
@@ -733,6 +767,26 @@ fn extract_tool_arg(tool_use: &Value) -> String {
         }
     }
     String::new()
+}
+
+/// Redact common secret patterns to avoid displaying credentials in the TUI.
+/// Replaces the prefix and all following non-whitespace chars with [REDACTED].
+fn redact_secrets(s: &str) -> String {
+    let patterns = [
+        "sk_live_", "sk_test_", "sk-ant-", "ghp_", "gho_",
+        "glpat-", "xoxb-", "xoxp-", "AKIA",
+    ];
+    let mut result = s.to_string();
+    for pat in &patterns {
+        while let Some(pos) = result.find(pat) {
+            // Redact from prefix through end of contiguous non-whitespace
+            let end = result[pos..].find(char::is_whitespace)
+                .map(|i| pos + i)
+                .unwrap_or(result.len());
+            result.replace_range(pos..end, "[REDACTED]");
+        }
+    }
+    result
 }
 
 fn shorten_path(path: &str) -> String {

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -763,7 +763,7 @@ fn extract_tool_arg(tool_use: &Value) -> String {
         // Bash: command (first 40 chars, redact secrets)
         if let Some(cmd) = input.get("command").and_then(|c| c.as_str()) {
             let short = cmd.lines().next().unwrap_or(cmd);
-            return redact_secrets(&truncate(short, 40));
+            return super::redact_secrets(&truncate(short, 40));
         }
         // Grep/Glob: pattern
         if let Some(pat) = input.get("pattern").and_then(|p| p.as_str()) {
@@ -771,26 +771,6 @@ fn extract_tool_arg(tool_use: &Value) -> String {
         }
     }
     String::new()
-}
-
-/// Redact common secret patterns to avoid displaying credentials in the TUI.
-/// Replaces the prefix and all following non-whitespace chars with [REDACTED].
-fn redact_secrets(s: &str) -> String {
-    let patterns = [
-        "sk_live_", "sk_test_", "sk-ant-", "ghp_", "gho_",
-        "glpat-", "xoxb-", "xoxp-", "AKIA",
-    ];
-    let mut result = s.to_string();
-    for pat in &patterns {
-        while let Some(pos) = result.find(pat) {
-            // Redact from prefix through end of contiguous non-whitespace
-            let end = result[pos..].find(char::is_whitespace)
-                .map(|i| pos + i)
-                .unwrap_or(result.len());
-            result.replace_range(pos..end, "[REDACTED]");
-        }
-    }
-    result
 }
 
 fn shorten_path(path: &str) -> String {

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -81,6 +81,10 @@ impl CodexCollector {
         if let Some(recent_dir) = Self::today_session_dir(&self.sessions_dir) {
             if let Ok(entries) = fs::read_dir(&recent_dir) {
                 for entry in entries.flatten() {
+                    // Skip symlinks to avoid reading unintended files
+                    if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(true) {
+                        continue;
+                    }
                     let path = entry.path();
                     if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                         continue;
@@ -211,7 +215,11 @@ impl CodexCollector {
                 .get(&p)
                 .cloned()
                 .unwrap_or_default();
+            let mut visited = std::collections::HashSet::new();
             while let Some(cpid) = stack.pop() {
+                if !visited.insert(cpid) {
+                    continue;
+                }
                 if let Some(cproc) = process_info.get(&cpid) {
                     let port = ports.get(&cpid).and_then(|v| v.first().copied());
                     children.push(ChildProcess {

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -458,12 +458,11 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                             result.context_window = cw;
                         }
                     }
-                    Some("user_message") => {
-                        if result.initial_prompt.is_empty() {
+                    Some("user_message")
+                        if result.initial_prompt.is_empty() => {
                             if let Some(msg) = payload["message"].as_str() {
                                 result.initial_prompt = msg.chars().take(120).collect();
                             }
-                        }
                     }
                     Some("token_count") => {
                         let info = &payload["info"];

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -3,7 +3,7 @@ use crate::model::{AgentSession, ChildProcess, RateLimitInfo, SessionStatus};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -377,7 +377,7 @@ struct CodexJSONLResult {
 /// - turn_context: model, effort
 fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
     let file = fs::File::open(path).ok()?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
 
     let mut result = CodexJSONLResult {
         session_id: String::new(),
@@ -401,18 +401,33 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
         rate_limit: None,
     };
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
+    // Match Claude transcript cap: a malformed/hostile line beyond this size
+    // aborts the scan to prevent OOM. take(MAX+1) physically bounds the read.
+    const MAX_LINE_BYTES: usize = 10 * 1024 * 1024;
+    let mut line_buf = String::new();
+    loop {
+        line_buf.clear();
+        match reader
+            .by_ref()
+            .take(MAX_LINE_BYTES as u64 + 1)
+            .read_line(&mut line_buf)
+        {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+        // Cap hit without a newline — skip this file's remainder.
+        if line_buf.len() > MAX_LINE_BYTES && !line_buf.ends_with('\n') {
+            break;
+        }
+        let line = line_buf.trim();
         if line.is_empty() {
             continue;
         }
 
-        let val: Value = match serde_json::from_str(&line) {
+        let val: Value = match serde_json::from_str(line) {
             Ok(v) => v,
-            Err(_) => continue, // partial line at EOF
+            Err(_) => continue, // partial line at EOF or malformed
         };
 
         // Update last_activity from timestamp
@@ -460,7 +475,8 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                     }
                     Some("user_message") if result.initial_prompt.is_empty() => {
                         if let Some(msg) = payload["message"].as_str() {
-                            result.initial_prompt = msg.chars().take(120).collect();
+                            let truncated: String = msg.chars().take(120).collect();
+                            result.initial_prompt = super::redact_secrets(&truncated);
                         }
                     }
                     Some("token_count") => {
@@ -486,7 +502,9 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                                 .or_else(|| last["cache_read_input_tokens"].as_u64())
                                 .unwrap_or(0);
                             result.last_context_tokens = inp + cache;
-                            result.token_history.push(inp + out + cache);
+                            if result.token_history.len() < 10_000 {
+                                result.token_history.push(inp + out + cache);
+                            }
                         }
                         // Context window may also appear inside info
                         if let Some(cw) = info["model_context_window"].as_u64() {
@@ -552,9 +570,10 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                         if arg.is_empty() {
                             result.current_task = name.to_string();
                         } else {
-                            // Shorten path: just filename
+                            // Shorten path: just filename, then redact any secrets
                             let short = arg.rsplit('/').next().unwrap_or(&arg);
-                            result.current_task = format!("{} {}", name, short);
+                            let redacted = super::redact_secrets(short);
+                            result.current_task = format!("{} {}", name, redacted);
                         }
                     }
                 }

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -7,6 +7,39 @@ pub use claude::ClaudeCollector;
 pub use codex::CodexCollector;
 pub use rate_limit::read_rate_limits;
 
+/// Redact common secret patterns to avoid displaying credentials in the TUI.
+/// Replaces the prefix and all following non-whitespace chars with [REDACTED].
+/// Best-effort: covers well-known prefixed tokens, not arbitrary high-entropy strings.
+pub(crate) fn redact_secrets(s: &str) -> String {
+    const PATTERNS: &[&str] = &[
+        // Anthropic / OpenAI / OpenRouter
+        "sk-ant-", "sk-proj-", "sk-or-",
+        // Stripe
+        "sk_live_", "sk_test_", "rk_live_", "rk_test_",
+        // GitHub
+        "ghp_", "gho_", "ghs_", "ghr_", "ghu_", "github_pat_",
+        // GitLab
+        "glpat-",
+        // Slack
+        "xoxb-", "xoxp-", "xoxa-", "xoxs-",
+        // AWS access key id
+        "AKIA", "ASIA",
+        // Bearer-prefixed headers
+        "Bearer ",
+    ];
+    let mut result = s.to_string();
+    for pat in PATTERNS {
+        while let Some(pos) = result.find(pat) {
+            let end = result[pos..]
+                .find(char::is_whitespace)
+                .map(|i| pos + i)
+                .unwrap_or(result.len());
+            result.replace_range(pos..end, "[REDACTED]");
+        }
+    }
+    result
+}
+
 use crate::model::{AgentSession, OrphanPort, RateLimitInfo, SessionStatus};
 use std::collections::HashMap;
 

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -58,7 +58,11 @@ pub fn has_active_descendant(
     cpu_threshold: f64,
 ) -> bool {
     let mut stack = vec![pid];
+    let mut visited = std::collections::HashSet::new();
     while let Some(p) = stack.pop() {
+        if !visited.insert(p) {
+            continue;
+        }
         if let Some(kids) = children_map.get(&p) {
             for &kid in kids {
                 if process_info.get(&kid).is_some_and(|p| p.cpu_pct > cpu_threshold) {
@@ -113,6 +117,10 @@ pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
 }
 
 pub fn collect_git_stats(cwd: &str) -> (u32, u32) {
+    // Validate cwd is an existing directory before running git
+    if !std::path::Path::new(cwd).is_dir() {
+        return (0, 0);
+    }
     let output = Command::new("git")
         .args(["-C", cwd, "status", "--porcelain"])
         .output()

--- a/src/collector/rate_limit.rs
+++ b/src/collector/rate_limit.rs
@@ -37,6 +37,7 @@ pub fn read_rate_limits() -> Vec<RateLimitInfo> {
     if let Some(claude_dir) = std::env::var("CLAUDE_CONFIG_DIR")
         .ok()
         .map(PathBuf::from)
+        .filter(|p| p.is_dir())
         .or_else(|| dirs::home_dir().map(|h| h.join(".claude")))
     {
         let path = claude_dir.join(CLAUDE_RATE_FILE);

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,9 +165,18 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
     Ok(())
 }
 
-/// Strip control characters (including ANSI escapes) from a string for safe terminal output.
+/// Strip control characters (including ANSI escapes) and Unicode bidi
+/// overrides from a string for safe terminal output. Defeats CVE-2021-42574
+/// (Trojan Source) style attacks via RTLO/LRO/PDF/isolate characters.
 fn sanitize_output(s: &str) -> String {
-    s.chars().filter(|c| !c.is_control() || *c == ' ').collect()
+    s.chars()
+        .filter(|c| (!c.is_control() || *c == ' ')
+            && !matches!(*c,
+                '\u{202A}'..='\u{202E}'
+                | '\u{2066}'..='\u{2069}'
+                | '\u{200E}'
+                | '\u{200F}'))
+        .collect()
 }
 
 fn print_snapshot(app: &App) {
@@ -217,9 +226,13 @@ fn run_update() -> io::Result<()> {
     let current = env!("CARGO_PKG_VERSION");
     println!("abtop v{current} — checking for updates...\n");
 
-    // Download installer to a temporary file before executing (avoid curl|sh pipe)
-    let tmp_dir = std::env::temp_dir();
-    let installer = tmp_dir.join("abtop-installer.sh");
+    // Download to a private temp file (O_EXCL + random suffix) so a local
+    // attacker can't pre-place a symlink or swap the file mid-run.
+    let tmp = tempfile::Builder::new()
+        .prefix("abtop-installer-")
+        .suffix(".sh")
+        .tempfile()?;
+    let installer_path = tmp.path().to_path_buf();
 
     let dl_status = std::process::Command::new("curl")
         .args([
@@ -229,7 +242,7 @@ fn run_update() -> io::Result<()> {
             "https://github.com/graykode/abtop/releases/latest/download/abtop-installer.sh",
             "-o",
         ])
-        .arg(&installer)
+        .arg(&installer_path)
         .status()?;
 
     if !dl_status.success() {
@@ -240,15 +253,16 @@ fn run_update() -> io::Result<()> {
 
     // Show checksum so the user can verify if desired
     let _ = std::process::Command::new("sha256sum")
-        .arg(&installer)
+        .arg(&installer_path)
         .status();
 
     let status = std::process::Command::new("sh")
-        .arg(&installer)
+        .arg(&installer_path)
         .status()?;
 
-    // Clean up
-    let _ = std::fs::remove_file(&installer);
+    // NamedTempFile::drop removes the file; explicit drop to sequence it
+    // after sh exits.
+    drop(tmp);
 
     if !status.success() {
         eprintln!("\nUpdate failed. You can also update manually:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
 /// (Trojan Source) style attacks via RTLO/LRO/PDF/isolate characters.
 fn sanitize_output(s: &str) -> String {
     s.chars()
-        .filter(|c| (!c.is_control() || *c == ' ')
+        .filter(|c| !c.is_control()
             && !matches!(*c,
                 '\u{202A}'..='\u{202E}'
                 | '\u{2066}'..='\u{2069}'
@@ -251,10 +251,19 @@ fn run_update() -> io::Result<()> {
         std::process::exit(1);
     }
 
-    // Show checksum so the user can verify if desired
-    let _ = std::process::Command::new("sha256sum")
+    // Show checksum so the user can verify if desired.
+    // macOS ships `shasum` (Perl) by default, Linux ships `sha256sum` (coreutils).
+    let checksum_shown = std::process::Command::new("shasum")
+        .args(["-a", "256"])
         .arg(&installer_path)
-        .status();
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !checksum_shown {
+        let _ = std::process::Command::new("sha256sum")
+            .arg(&installer_path)
+            .status();
+    }
 
     let status = std::process::Command::new("sh")
         .arg(&installer_path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,11 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
     Ok(())
 }
 
+/// Strip control characters (including ANSI escapes) from a string for safe terminal output.
+fn sanitize_output(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control() || *c == ' ').collect()
+}
+
 fn print_snapshot(app: &App) {
     println!("abtop — {} sessions\n", app.sessions.len());
     for session in &app.sessions {
@@ -179,11 +184,11 @@ fn print_snapshot(app: &App) {
             &session.session_id
         };
         let project_label = format!("{}({})", session.project_name, sid_short);
-        let summary = app.session_summary(session);
+        let summary = sanitize_output(&app.session_summary(session));
         println!(
             "  {} {:<20} {} {} {:<10} CTX:{:>3.0}% Tok:{} Mem:{}M {}",
             session.pid,
-            project_label,
+            sanitize_output(&project_label),
             summary,
             status,
             session.model.replace("claude-", ""),
@@ -193,14 +198,14 @@ fn print_snapshot(app: &App) {
             session.elapsed_display(),
         );
         if let Some(task) = session.current_tasks.last() {
-            println!("       └─ {}", task);
+            println!("       └─ {}", sanitize_output(task));
         }
         for child in &session.children {
             let port = child.port.map(|p| format!(":{}", p)).unwrap_or_default();
             println!(
                 "       {} {} {}K {}",
                 child.pid,
-                child.command.split_whitespace().take(3).collect::<Vec<_>>().join(" "),
+                sanitize_output(&child.command.split_whitespace().take(3).collect::<Vec<_>>().join(" ")),
                 child.mem_kb / 1024,
                 port,
             );
@@ -212,10 +217,38 @@ fn run_update() -> io::Result<()> {
     let current = env!("CARGO_PKG_VERSION");
     println!("abtop v{current} — checking for updates...\n");
 
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg("curl --proto '=https' --tlsv1.2 -LsSf https://github.com/graykode/abtop/releases/latest/download/abtop-installer.sh | sh")
+    // Download installer to a temporary file before executing (avoid curl|sh pipe)
+    let tmp_dir = std::env::temp_dir();
+    let installer = tmp_dir.join("abtop-installer.sh");
+
+    let dl_status = std::process::Command::new("curl")
+        .args([
+            "--proto", "=https",
+            "--tlsv1.2",
+            "-LsSf",
+            "https://github.com/graykode/abtop/releases/latest/download/abtop-installer.sh",
+            "-o",
+        ])
+        .arg(&installer)
         .status()?;
+
+    if !dl_status.success() {
+        eprintln!("\nDownload failed. You can also update manually:");
+        eprintln!("  cargo install abtop --force");
+        std::process::exit(1);
+    }
+
+    // Show checksum so the user can verify if desired
+    let _ = std::process::Command::new("sha256sum")
+        .arg(&installer)
+        .status();
+
+    let status = std::process::Command::new("sh")
+        .arg(&installer)
+        .status()?;
+
+    // Clean up
+    let _ = std::fs::remove_file(&installer);
 
     if !status.success() {
         eprintln!("\nUpdate failed. You can also update manually:");

--- a/src/model/session.rs
+++ b/src/model/session.rs
@@ -127,6 +127,26 @@ pub struct SessionFile {
     pub started_at: u64,
 }
 
+impl SessionFile {
+    /// Truncate string fields to sane limits after deserialization.
+    pub fn sanitize(&mut self) {
+        truncate_string(&mut self.session_id, 256);
+        truncate_string(&mut self.cwd, 4096);
+    }
+}
+
+/// Truncate a string at a char boundary to avoid panics on multi-byte UTF-8.
+fn truncate_string(s: &mut String, max_bytes: usize) {
+    if s.len() > max_bytes {
+        // Find the last char boundary at or before max_bytes
+        let mut end = max_bytes;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s.truncate(end);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -34,8 +34,10 @@ with open(os.path.join(config_dir, 'abtop-rate-limits.json'), 'w') as f:
 
 fn claude_dir() -> PathBuf {
     std::env::var("CLAUDE_CONFIG_DIR")
+        .ok()
         .map(PathBuf::from)
-        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".claude"))
+        .filter(|p| p.is_dir())
+        .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".claude"))
 }
 
 fn script_path() -> PathBuf {
@@ -64,7 +66,7 @@ pub fn run_setup() {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = fs::set_permissions(&script, fs::Permissions::from_mode(0o755));
+                let _ = fs::set_permissions(&script, fs::Permissions::from_mode(0o700));
             }
             println!("  ✓ wrote {}", script.display());
         }
@@ -99,11 +101,12 @@ pub fn run_setup() {
     let obj = settings.as_object_mut().unwrap();
 
     // Check if statusLine is already configured
+    let expected_cmd = script.display().to_string();
     if let Some(existing) = obj.get("statusLine") {
         if let Some(existing_obj) = existing.as_object() {
             if let Some(cmd) = existing_obj.get("command") {
                 let cmd_str = cmd.as_str().unwrap_or("");
-                if !cmd_str.contains("abtop") {
+                if cmd_str != expected_cmd && !cmd_str.is_empty() {
                     eprintln!("  ⚠ statusLine already configured: {}", cmd_str);
                     eprintln!("    to override, remove the existing statusLine key from:");
                     eprintln!("    {}", settings_file.display());


### PR DESCRIPTION
## Summary

Hardens abtop against local attack vectors. While abtop reads only local files with no network activity, the files it reads (session transcripts, JSONL logs, config) are writable by other processes on the same machine. A compromised or malicious Claude Code session could craft payloads targeting abtop's parsing.

## Threat model

Local attacker with write access to `~/.claude/` (e.g. malicious MCP server, compromised subagent, rogue extension) attempting: symlink exploitation, PID reuse for kill misdirection, OOM via crafted transcripts, terminal injection via bidi overrides, credential exfiltration via tool arg display, or installer supply chain hijack.

## Changes

**Commit 1 - core hardening:**
- Verify PID command before kill to prevent TOCTOU race on PID reuse
- Skip symlinks in all session/transcript/subagent file reads (fail-closed on error)
- Add visited set to all 3 process tree walkers to prevent infinite loops
- Cap `token_history` (10K entries) and JSONL line buffer (10MB) to prevent OOM
- Validate `CLAUDE_CONFIG_DIR` as existing directory before use
- Atomic write for summary cache (temp + rename)
- Harden statusline hook setup: exact match check, `0o700` permissions
- Download update installer to file before executing (no more `curl | sh`)
- Sanitize `--once` output: strip terminal escape sequences
- Redact common secret patterns (`sk-ant-`, `ghp_`, `gho_`, `glpat-`, `xoxb-`, `AKIA`, ...) in tool arg display
- Truncate deserialized session fields at char boundaries (no UTF-8 panic)

**Commit 2 - follow-up tightening:**
- Replace predictable `/tmp/abtop-installer.sh` with `tempfile::NamedTempFile` (O_EXCL + random suffix) to prevent symlink planting
- Cap `read_line` via `.take(MAX+1)` instead of post-read check (the previous check fired after the buffer had already grown unbounded)
- Extend `sanitize_output` to strip Unicode bidi overrides (U+202A-U+202E, U+2066-U+2069, U+200E, U+200F) - closes CVE-2021-42574 Trojan Source vector

## Testing

- `cargo clippy -- -D warnings` - clean
- `cargo test` - 31/31 pass
- `cargo build --release` - compiles, binary functional
- Manual: `abtop --once` with active sessions, verified sanitized output