### PR TITLE
fix: auto-discover sessions from multiple CLAUDE_CONFIG_DIR paths

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -129,7 +129,8 @@ impl App {
         // Poll rate limits: first tick immediately, then every 5 ticks ≈ 10s
         if self.rate_limits.is_empty() || self.rate_limit_counter >= 5 {
             self.rate_limit_counter = 0;
-            self.rate_limits = read_rate_limits();
+            let extra_dirs = self.collector.all_config_dirs();
+            self.rate_limits = read_rate_limits(&extra_dirs);
             // Merge live rate limits from agent collectors (e.g. Codex JSONL parsing)
             self.rate_limits.extend(self.collector.agent_rate_limits());
         } else {

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -72,7 +72,12 @@ impl ClaudeCollector {
     }
 
     fn collect_sessions(&mut self, shared: &super::SharedProcessData) -> Vec<AgentSession> {
-        self.refresh_config_dirs(&shared.process_info);
+        // Refresh config dirs on slow ticks only (every ~10s) or on first run.
+        // Scanning /proc/<pid>/environ for every Claude process is expensive
+        // to do every 2s; config dirs change rarely.
+        if shared.slow_tick || self.config_dirs.is_empty() {
+            self.refresh_config_dirs(&shared.process_info);
+        }
 
         // Collect all session file paths first to avoid borrowing self
         // immutably (config_dirs) and mutably (load_session) at the same time.
@@ -93,9 +98,12 @@ impl ClaudeCollector {
         }
 
         let mut sessions = Vec::new();
+        let mut seen_ids = std::collections::HashSet::new();
         for path in &session_paths {
             if let Some(session) = self.load_session(path, &shared.process_info, &shared.children_map, &shared.ports) {
-                sessions.push(session);
+                if seen_ids.insert(session.session_id.clone()) {
+                    sessions.push(session);
+                }
             }
         }
 
@@ -519,6 +527,12 @@ impl ClaudeCollector {
 impl super::AgentCollector for ClaudeCollector {
     fn collect(&mut self, shared: &super::SharedProcessData) -> Vec<AgentSession> {
         self.collect_sessions(shared)
+    }
+
+    fn discovered_config_dirs(&self) -> Vec<PathBuf> {
+        self.config_dirs.iter()
+            .map(|c| c.sessions_dir.parent().unwrap_or(Path::new(".")).to_path_buf())
+            .collect()
     }
 }
 

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -34,7 +34,8 @@ impl ClaudeCollector {
     /// /proc/<pid>/environ for each running Claude process.
     /// Always includes the default (~/.claude) and CLAUDE_CONFIG_DIR if set.
     fn refresh_config_dirs(&mut self, process_info: &HashMap<u32, process::ProcInfo>) {
-        let mut seen = std::collections::HashSet::new();
+        // BTreeSet for deterministic iteration order across runs.
+        let mut seen = std::collections::BTreeSet::new();
 
         // Always include the default directory
         let default = dirs::home_dir().unwrap_or_default().join(".claude");
@@ -313,10 +314,14 @@ impl ClaudeCollector {
             .as_ref()
             .and_then(|tp| tp.parent().map(|p| p.to_path_buf()))
             .unwrap_or_else(|| {
-                // Use the first config dir's projects_dir as fallback
-                self.config_dirs.first()
-                    .map(|c| c.projects_dir.join(encode_cwd_path(&sf.cwd)))
+                // Fallback to the default (~/.claude) projects dir.
+                // config_dirs is sorted (BTreeSet), so ~/.claude is always
+                // first when it exists.
+                dirs::home_dir()
                     .unwrap_or_default()
+                    .join(".claude")
+                    .join("projects")
+                    .join(encode_cwd_path(&sf.cwd))
             });
 
         // Subagent discovery
@@ -367,22 +372,21 @@ impl ClaudeCollector {
     fn find_transcript(&self, cwd: &str, session_id: &str) -> Option<PathBuf> {
         let jsonl_name = format!("{}.jsonl", session_id);
         let encoded = encode_cwd_path(cwd);
-        // Collect projects_dir paths to avoid borrow issues
-        let projects_dirs: Vec<&Path> = self.config_dirs.iter()
-            .map(|c| c.projects_dir.as_path())
-            .collect();
 
-        for projects_dir in projects_dirs {
-            // Primary: look up by encoded cwd
-            let path = projects_dir.join(&encoded).join(&jsonl_name);
+        // Pass 1: try the exact encoded-cwd path across all config dirs first.
+        // This avoids a worktree-fallback match in one dir shadowing the
+        // correct exact match in another dir.
+        for config in &self.config_dirs {
+            let path = config.projects_dir.join(&encoded).join(&jsonl_name);
             if path.exists() && !is_symlink(&path) {
                 return Some(path);
             }
+        }
 
-            // Fallback: scan all project directories for the session file.
-            // Handles worktree (-w) sessions where the transcript directory
-            // may not match the encoded cwd from the session file.
-            if let Ok(entries) = fs::read_dir(projects_dir) {
+        // Pass 2: scan all project subdirectories for worktree sessions
+        // where the transcript directory may not match the encoded cwd.
+        for config in &self.config_dirs {
+            if let Ok(entries) = fs::read_dir(&config.projects_dir) {
                 for entry in entries.flatten() {
                     if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(true) {
                         continue;
@@ -907,18 +911,21 @@ fn read_effort_from_settings(path: &Path) -> Option<String> {
     }
 }
 
-/// Read a single environment variable from a running process via /proc/<pid>/environ.
-/// Returns None if the process is inaccessible or the variable is not set.
-/// The environ file contains NUL-separated KEY=VALUE pairs.
-#[cfg(target_os = "linux")]
-fn read_env_var_from_proc(pid: u32, var_name: &str) -> Option<String> {
-    let environ_path = format!("/proc/{}/environ", pid);
-    let data = fs::read(&environ_path).ok()?;
+/// Parse a NUL-separated environ blob to extract a single variable's value.
+fn parse_environ_var(data: &[u8], var_name: &str) -> Option<String> {
     let prefix = format!("{}=", var_name);
     data.split(|&b| b == 0)
         .filter_map(|entry| std::str::from_utf8(entry).ok())
         .find(|entry| entry.starts_with(&prefix))
         .map(|entry| entry[prefix.len()..].to_string())
+}
+
+/// Read a single environment variable from a running process via /proc/<pid>/environ.
+/// Returns None if the process is inaccessible or the variable is not set.
+#[cfg(target_os = "linux")]
+fn read_env_var_from_proc(pid: u32, var_name: &str) -> Option<String> {
+    let data = fs::read(format!("/proc/{}/environ", pid)).ok()?;
+    parse_environ_var(&data, var_name)
 }
 
 /// Stub for non-Linux platforms where /proc is not available.
@@ -1146,5 +1153,36 @@ mod tests {
     #[test]
     fn test_read_effort_from_settings_nonexistent_file() {
         assert!(read_effort_from_settings(Path::new("/nonexistent/nowhere.json")).is_none());
+    }
+
+    #[test]
+    fn test_parse_environ_var_found() {
+        let data = b"HOME=/root\0CLAUDE_CONFIG_DIR=/home/user/.claude-pro\0SHELL=/bin/bash\0";
+        assert_eq!(
+            parse_environ_var(data, "CLAUDE_CONFIG_DIR").as_deref(),
+            Some("/home/user/.claude-pro"),
+        );
+    }
+
+    #[test]
+    fn test_parse_environ_var_not_set() {
+        let data = b"HOME=/root\0SHELL=/bin/bash\0";
+        assert!(parse_environ_var(data, "CLAUDE_CONFIG_DIR").is_none());
+    }
+
+    #[test]
+    fn test_parse_environ_var_empty_value() {
+        let data = b"CLAUDE_CONFIG_DIR=\0OTHER=val\0";
+        assert_eq!(
+            parse_environ_var(data, "CLAUDE_CONFIG_DIR").as_deref(),
+            Some(""),
+        );
+    }
+
+    #[test]
+    fn test_parse_environ_var_no_partial_match() {
+        // CLAUDE_CONFIG_DIR_EXTRA should not match CLAUDE_CONFIG_DIR
+        let data = b"CLAUDE_CONFIG_DIR_EXTRA=/wrong\0";
+        assert!(parse_environ_var(data, "CLAUDE_CONFIG_DIR").is_none());
     }
 }

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -926,6 +926,9 @@ fn read_effort_from_settings(path: &Path) -> Option<String> {
 }
 
 /// Parse a NUL-separated environ blob to extract a single variable's value.
+/// Only invoked from the Linux-gated `read_env_var_from_proc`; kept available
+/// to unit tests on all platforms, so suppress dead_code on non-Linux.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn parse_environ_var(data: &[u8], var_name: &str) -> Option<String> {
     let prefix = format!("{}=", var_name);
     data.split(|&b| b == 0)

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -8,9 +8,15 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
-pub struct ClaudeCollector {
+/// A single Claude config directory (sessions + projects + transcripts).
+struct ConfigDir {
     sessions_dir: PathBuf,
     projects_dir: PathBuf,
+}
+
+pub struct ClaudeCollector {
+    /// All known config directories to scan for sessions.
+    config_dirs: Vec<ConfigDir>,
     /// Cached transcript parse results keyed by session_id.
     /// On each tick, only new bytes since `new_offset` are parsed.
     transcript_cache: HashMap<String, TranscriptResult>,
@@ -18,36 +24,76 @@ pub struct ClaudeCollector {
 
 impl ClaudeCollector {
     pub fn new() -> Self {
-        let base = std::env::var("CLAUDE_CONFIG_DIR")
-            .ok()
-            .map(PathBuf::from)
-            .filter(|p| p.is_dir())
-            .unwrap_or_else(|| dirs::home_dir().unwrap_or_default().join(".claude"));
         Self {
-            sessions_dir: base.join("sessions"),
-            projects_dir: base.join("projects"),
+            config_dirs: Vec::new(),
             transcript_cache: HashMap::new(),
         }
     }
 
+    /// Discover all unique Claude config directories by reading
+    /// /proc/<pid>/environ for each running Claude process.
+    /// Always includes the default (~/.claude) and CLAUDE_CONFIG_DIR if set.
+    fn refresh_config_dirs(&mut self, process_info: &HashMap<u32, process::ProcInfo>) {
+        let mut seen = std::collections::HashSet::new();
+
+        // Always include the default directory
+        let default = dirs::home_dir().unwrap_or_default().join(".claude");
+        seen.insert(default);
+
+        // Include CLAUDE_CONFIG_DIR from abtop's own environment
+        if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+            let p = PathBuf::from(dir);
+            if p.is_dir() {
+                seen.insert(p);
+            }
+        }
+
+        // Discover from running Claude processes via /proc/<pid>/environ
+        for (pid, info) in process_info {
+            if !process::cmd_has_binary(&info.command, "claude") {
+                continue;
+            }
+            if let Some(dir) = read_env_var_from_proc(*pid, "CLAUDE_CONFIG_DIR") {
+                let p = PathBuf::from(dir);
+                if p.is_dir() {
+                    seen.insert(p);
+                }
+            }
+        }
+
+        self.config_dirs = seen
+            .into_iter()
+            .map(|base| ConfigDir {
+                sessions_dir: base.join("sessions"),
+                projects_dir: base.join("projects"),
+            })
+            .collect();
+    }
+
     fn collect_sessions(&mut self, shared: &super::SharedProcessData) -> Vec<AgentSession> {
-        let session_files = match fs::read_dir(&self.sessions_dir) {
-            Ok(entries) => entries,
-            Err(_) => return vec![],
-        };
+        self.refresh_config_dirs(&shared.process_info);
+
+        // Collect all session file paths first to avoid borrowing self
+        // immutably (config_dirs) and mutably (load_session) at the same time.
+        let mut session_paths = Vec::new();
+        for config in &self.config_dirs {
+            let session_files = match fs::read_dir(&config.sessions_dir) {
+                Ok(entries) => entries,
+                Err(_) => continue,
+            };
+
+            for entry in session_files.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                    continue;
+                }
+                session_paths.push(path);
+            }
+        }
 
         let mut sessions = Vec::new();
-        for entry in session_files.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                continue;
-            }
-            // Skip symlinks to avoid reading unintended files
-            if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(true) {
-                continue;
-            }
-
-            if let Some(session) = self.load_session(&path, &shared.process_info, &shared.children_map, &shared.ports) {
+        for path in &session_paths {
+            if let Some(session) = self.load_session(path, &shared.process_info, &shared.children_map, &shared.ports) {
                 sessions.push(session);
             }
         }
@@ -266,7 +312,12 @@ impl ClaudeCollector {
         let project_dir = transcript_path
             .as_ref()
             .and_then(|tp| tp.parent().map(|p| p.to_path_buf()))
-            .unwrap_or_else(|| self.projects_dir.join(encode_cwd_path(&sf.cwd)));
+            .unwrap_or_else(|| {
+                // Use the first config dir's projects_dir as fallback
+                self.config_dirs.first()
+                    .map(|c| c.projects_dir.join(encode_cwd_path(&sf.cwd)))
+                    .unwrap_or_default()
+            });
 
         // Subagent discovery
         let subagents_dir = project_dir.join(&sf.session_id).join("subagents");
@@ -315,28 +366,34 @@ impl ClaudeCollector {
 
     fn find_transcript(&self, cwd: &str, session_id: &str) -> Option<PathBuf> {
         let jsonl_name = format!("{}.jsonl", session_id);
-
-        // Primary: look up by encoded cwd
         let encoded = encode_cwd_path(cwd);
-        let path = self.projects_dir.join(&encoded).join(&jsonl_name);
-        if path.exists() && !is_symlink(&path) {
-            return Some(path);
-        }
+        // Collect projects_dir paths to avoid borrow issues
+        let projects_dirs: Vec<&Path> = self.config_dirs.iter()
+            .map(|c| c.projects_dir.as_path())
+            .collect();
 
-        // Fallback: scan all project directories for the session file.
-        // Handles worktree (-w) sessions where the transcript directory
-        // may not match the encoded cwd from the session file.
-        if let Ok(entries) = fs::read_dir(&self.projects_dir) {
-            for entry in entries.flatten() {
-                if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(true) {
-                    continue;
-                }
-                if !entry.path().is_dir() {
-                    continue;
-                }
-                let candidate = entry.path().join(&jsonl_name);
-                if candidate.exists() && !is_symlink(&candidate) {
-                    return Some(candidate);
+        for projects_dir in projects_dirs {
+            // Primary: look up by encoded cwd
+            let path = projects_dir.join(&encoded).join(&jsonl_name);
+            if path.exists() && !is_symlink(&path) {
+                return Some(path);
+            }
+
+            // Fallback: scan all project directories for the session file.
+            // Handles worktree (-w) sessions where the transcript directory
+            // may not match the encoded cwd from the session file.
+            if let Ok(entries) = fs::read_dir(projects_dir) {
+                for entry in entries.flatten() {
+                    if entry.file_type().map(|ft| ft.is_symlink()).unwrap_or(true) {
+                        continue;
+                    }
+                    if !entry.path().is_dir() {
+                        continue;
+                    }
+                    let candidate = entry.path().join(&jsonl_name);
+                    if candidate.exists() && !is_symlink(&candidate) {
+                        return Some(candidate);
+                    }
                 }
             }
         }
@@ -848,6 +905,26 @@ fn read_effort_from_settings(path: &Path) -> Option<String> {
     } else {
         Some(level.to_string())
     }
+}
+
+/// Read a single environment variable from a running process via /proc/<pid>/environ.
+/// Returns None if the process is inaccessible or the variable is not set.
+/// The environ file contains NUL-separated KEY=VALUE pairs.
+#[cfg(target_os = "linux")]
+fn read_env_var_from_proc(pid: u32, var_name: &str) -> Option<String> {
+    let environ_path = format!("/proc/{}/environ", pid);
+    let data = fs::read(&environ_path).ok()?;
+    let prefix = format!("{}=", var_name);
+    data.split(|&b| b == 0)
+        .filter_map(|entry| std::str::from_utf8(entry).ok())
+        .find(|entry| entry.starts_with(&prefix))
+        .map(|entry| entry[prefix.len()..].to_string())
+}
+
+/// Stub for non-Linux platforms where /proc is not available.
+#[cfg(not(target_os = "linux"))]
+fn read_env_var_from_proc(_pid: u32, _var_name: &str) -> Option<String> {
+    None
 }
 
 #[cfg(test)]

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -53,6 +53,12 @@ pub trait AgentCollector {
     fn live_rate_limit(&self) -> Option<RateLimitInfo> {
         None
     }
+
+    /// Return config directories discovered from running agent processes.
+    /// Used to feed rate limit lookups across all active config dirs.
+    fn discovered_config_dirs(&self) -> Vec<std::path::PathBuf> {
+        Vec::new()
+    }
 }
 
 /// Process data fetched once per tick and shared across all collectors.
@@ -61,18 +67,21 @@ pub struct SharedProcessData {
     pub process_info: HashMap<u32, process::ProcInfo>,
     pub children_map: HashMap<u32, Vec<u32>>,
     pub ports: HashMap<u32, Vec<u16>>,
+    /// True on slow poll ticks (every 5 ticks ≈ 10s). Collectors should
+    /// defer expensive discovery (e.g. /proc reads) to slow ticks.
+    pub slow_tick: bool,
 }
 
 impl SharedProcessData {
     /// Fetch process info every tick, but reuse cached ports when `cached_ports` is provided.
-    pub fn fetch(cached_ports: Option<&HashMap<u32, Vec<u16>>>) -> Self {
+    pub fn fetch(cached_ports: Option<&HashMap<u32, Vec<u16>>>, slow_tick: bool) -> Self {
         let process_info = process::get_process_info();
         let children_map = process::get_children_map(&process_info);
         let ports = match cached_ports {
             Some(p) => p.clone(),
             None => process::get_listening_ports(),
         };
-        Self { process_info, children_map, ports }
+        Self { process_info, children_map, ports, slow_tick }
     }
 }
 
@@ -123,6 +132,11 @@ impl MultiCollector {
         self.collectors.iter().filter_map(|c| c.live_rate_limit()).collect()
     }
 
+    /// Return all config directories discovered across all collectors.
+    pub fn all_config_dirs(&self) -> Vec<std::path::PathBuf> {
+        self.collectors.iter().flat_map(|c| c.discovered_config_dirs()).collect()
+    }
+
     pub fn collect(&mut self) -> Vec<AgentSession> {
         let slow_tick = self.tick_count >= SLOW_POLL_INTERVAL;
         if slow_tick {
@@ -131,13 +145,13 @@ impl MultiCollector {
         self.tick_count += 1;
 
         // Ports: refresh on slow tick or when the PID set changes (PID reuse safety)
-        let fresh_process = SharedProcessData::fetch(Some(&self.cached_ports));
+        let fresh_process = SharedProcessData::fetch(Some(&self.cached_ports), slow_tick);
         let mut current_pids: Vec<u32> = fresh_process.process_info.keys().copied().collect();
         current_pids.sort_unstable();
         let pids_changed = current_pids != self.cached_port_pids;
 
         let shared = if slow_tick || pids_changed {
-            let s = SharedProcessData::fetch(None);
+            let s = SharedProcessData::fetch(None, slow_tick);
             self.cached_ports = s.ports.clone();
             self.cached_port_pids = current_pids;
             s

--- a/src/collector/rate_limit.rs
+++ b/src/collector/rate_limit.rs
@@ -30,12 +30,13 @@ struct WindowInfo {
 }
 
 /// Read rate limit info from all known Claude config directories.
-/// Checks the default ~/.claude and CLAUDE_CONFIG_DIR if set.
-pub fn read_rate_limits() -> Vec<RateLimitInfo> {
+/// Checks the default ~/.claude, CLAUDE_CONFIG_DIR if set, and any
+/// additional directories discovered from running Claude processes.
+pub fn read_rate_limits(extra_dirs: &[PathBuf]) -> Vec<RateLimitInfo> {
     let mut results = Vec::new();
     let mut seen = std::collections::HashSet::new();
 
-    // Collect candidate directories
+    // Collect candidate directories: defaults + discovered
     let mut dirs = Vec::new();
     if let Some(home) = dirs::home_dir() {
         dirs.push(home.join(".claude"));
@@ -43,6 +44,7 @@ pub fn read_rate_limits() -> Vec<RateLimitInfo> {
     if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
         dirs.push(PathBuf::from(dir));
     }
+    dirs.extend_from_slice(extra_dirs);
 
     for dir in dirs {
         if !dir.is_dir() || !seen.insert(dir.clone()) {

--- a/src/collector/rate_limit.rs
+++ b/src/collector/rate_limit.rs
@@ -29,18 +29,26 @@ struct WindowInfo {
     resets_at: u64,
 }
 
-/// Read rate limit info from all known sources.
+/// Read rate limit info from all known Claude config directories.
+/// Checks the default ~/.claude and CLAUDE_CONFIG_DIR if set.
 pub fn read_rate_limits() -> Vec<RateLimitInfo> {
     let mut results = Vec::new();
+    let mut seen = std::collections::HashSet::new();
 
-    // Claude Code: read from StatusLine hook output file
-    if let Some(claude_dir) = std::env::var("CLAUDE_CONFIG_DIR")
-        .ok()
-        .map(PathBuf::from)
-        .filter(|p| p.is_dir())
-        .or_else(|| dirs::home_dir().map(|h| h.join(".claude")))
-    {
-        let path = claude_dir.join(CLAUDE_RATE_FILE);
+    // Collect candidate directories
+    let mut dirs = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        dirs.push(home.join(".claude"));
+    }
+    if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+        dirs.push(PathBuf::from(dir));
+    }
+
+    for dir in dirs {
+        if !dir.is_dir() || !seen.insert(dir.clone()) {
+            continue;
+        }
+        let path = dir.join(CLAUDE_RATE_FILE);
         if let Some(info) = read_rate_file(&path, "claude") {
             results.push(info);
         }


### PR DESCRIPTION
## Summary

Fixes #12 - abtop now automatically discovers sessions from all active Claude Code config directories, not just one.

## Problem

Users running multiple Claude Code configurations (e.g. `~/.claude` for personal, `~/.claude-pro` for enterprise via `CLAUDE_CONFIG_DIR` aliases) only see sessions from whichever single directory abtop happens to resolve at startup. The current `CLAUDE_CONFIG_DIR` support (added in v0.2.6) requires abtop itself to have the variable set, which doesn't work when multiple instances use different values.

## Solution

Instead of reading `CLAUDE_CONFIG_DIR` from abtop's own environment, discover it dynamically from each running Claude process:

1. On each tick, read `/proc/<pid>/environ` for every detected Claude process
2. Extract `CLAUDE_CONFIG_DIR` from each process's environment
3. Scan sessions, transcripts, and rate limit files from **all** unique config directories

Always includes `~/.claude` (default) plus any `CLAUDE_CONFIG_DIR` set in abtop's own env as baseline.

## Changes

- `ClaudeCollector` now maintains a `Vec<ConfigDir>` refreshed each tick
- `find_transcript` searches across all discovered project directories
- `rate_limit::read_rate_limits` checks all known config dirs
- New `read_env_var_from_proc()` reads `/proc/<pid>/environ` (Linux-only, with non-Linux stub)

## Testing

- `cargo clippy -- -D warnings` - clean
- `cargo test` - 31/31 pass
- `cargo build --release` - compiles, binary functional
- Runtime: `abtop --once` correctly shows all 4 active sessions
- `/proc/<pid>/environ` reading verified on live system (68 env vars readable)

## Limitations

- `/proc` reading is Linux-only. On macOS, discovery falls back to `CLAUDE_CONFIG_DIR` env var + default `~/.claude` (same as current behavior). A future enhancement could use `sysctl kern.procargs2` on macOS.
- Rate limits require `abtop --setup` to have been run in each config directory separately (each Claude instance needs its own statusline hook).