### PR TITLE
chore: reduce tokio features to rt+macros

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,6 @@ Tracks child processes that have open ports. When a parent session dies but the 
 - **Rust** (2021 edition)
 - **ratatui** + **crossterm** for TUI
 - **serde** + **serde_json** for JSON/JSONL parsing
-- **tokio** — included but currently sync I/O; summary generation uses `std::thread::spawn`
 - **chrono** for timestamp formatting
 - **dirs** for home directory resolution
 - **Polling intervals** (staggered to avoid freezes):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
 ]
 
 [[package]]
@@ -54,12 +53,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cassowary"
@@ -514,12 +507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,16 +718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,34 +789,6 @@ name = "thiserror-impl"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio"
-version = "1.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ authors = ["Tae Hwan Jung <nlkey2022@gmail.com>"]
 [dependencies]
 ratatui = "0.29"
 crossterm = "0.28"
-tokio = { version = "1", features = ["rt", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Tae Hwan Jung <nlkey2022@gmail.com>"]
 [dependencies]
 ratatui = "0.29"
 crossterm = "0.28"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -450,11 +450,9 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                             result.context_window = cw;
                         }
                     }
-                    Some("user_message") => {
-                        if result.initial_prompt.is_empty() {
-                            if let Some(msg) = payload["message"].as_str() {
-                                result.initial_prompt = msg.chars().take(120).collect();
-                            }
+                    Some("user_message") if result.initial_prompt.is_empty() => {
+                        if let Some(msg) = payload["message"].as_str() {
+                            result.initial_prompt = msg.chars().take(120).collect();
                         }
                     }
                     Some("token_count") => {

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -450,12 +450,11 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                             result.context_window = cw;
                         }
                     }
-                    Some("user_message") => {
-                        if result.initial_prompt.is_empty() {
+                    Some("user_message")
+                        if result.initial_prompt.is_empty() => {
                             if let Some(msg) = payload["message"].as_str() {
                                 result.initial_prompt = msg.chars().take(120).collect();
                             }
-                        }
                     }
                     Some("token_count") => {
                         let info = &payload["info"];

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -450,11 +450,12 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                             result.context_window = cw;
                         }
                     }
-                    Some("user_message")
-                        if result.initial_prompt.is_empty() => {
+                    Some("user_message") => {
+                        if result.initial_prompt.is_empty() {
                             if let Some(msg) = payload["message"].as_str() {
                                 result.initial_prompt = msg.chars().take(120).collect();
                             }
+                        }
                     }
                     Some("token_count") => {
                         let info = &payload["info"];


### PR DESCRIPTION
## Summary

- Reduce tokio features from `"full"` to `["rt", "macros"]`
- The codebase is fully synchronous (`fn main`, `std::thread::spawn`, `std::sync::mpsc`) with zero uses of `async`/`.await`/`tokio::` anywhere in `src/`
- `"full"` pulls in unused modules (net, fs, io-util, signal, sync::broadcast) and ~9 transitive crates that only increase compile time and attack surface

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` - all 25 tests pass
- [x] Verified: `grep -r "async\|tokio\|\.await" src/` returns zero matches

## Additional note

A `cargo-audit` CI job (`rustsec/audit-check@v2`) would also be valuable but requires the `workflow` scope to modify `.github/workflows/ci.yml`. Happy to add it in a follow-up if you prefer, or you can add it directly:

```yaml
  audit:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: rustsec/audit-check@v2
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
```