### PR TITLE
fix(quota): keep CLAUDE and CODEX sections visible across staleness

### DIFF
--- a/src/collector/rate_limit.rs
+++ b/src/collector/rate_limit.rs
@@ -1,7 +1,6 @@
 use crate::model::RateLimitInfo;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// File written by the StatusLine hook: ~/.claude/abtop-rate-limits.json
 const CLAUDE_RATE_FILE: &str = "abtop-rate-limits.json";
@@ -60,11 +59,12 @@ pub fn read_rate_limits(extra_dirs: &[PathBuf]) -> Vec<RateLimitInfo> {
 }
 
 /// Read cached Codex rate limit (fallback when no live session provides one).
-/// No staleness check — rate limits have their own `resets_at` expiry,
-/// and the cache is updated whenever the next Codex session runs.
+/// Rate limits have their own `resets_at` expiry and the cache is refreshed
+/// whenever the next Codex session runs, so the reader keeps serving the last
+/// known value regardless of file age — the UI shows "N m ago" for staleness.
 pub fn read_codex_cache() -> Option<RateLimitInfo> {
     let path = codex_cache_path()?;
-    read_rate_file_impl(&path, "codex", false)
+    read_rate_file(&path, "codex")
 }
 
 /// Write Codex rate limit to cache file (atomic: write temp + rename).
@@ -101,25 +101,8 @@ fn codex_cache_path() -> Option<PathBuf> {
 }
 
 fn read_rate_file(path: &Path, default_source: &str) -> Option<RateLimitInfo> {
-    read_rate_file_impl(path, default_source, true)
-}
-
-fn read_rate_file_impl(path: &Path, default_source: &str, check_staleness: bool) -> Option<RateLimitInfo> {
     let content = std::fs::read_to_string(path).ok()?;
     let file: RateLimitFile = serde_json::from_str(&content).ok()?;
-
-    // Ignore stale data (older than 10 minutes) when staleness check is enabled
-    if check_staleness {
-        if let Some(updated) = file.updated_at {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            if now.saturating_sub(updated) > 600 {
-                return None;
-            }
-        }
-    }
 
     // Reject if both windows are absent
     if file.five_hour.is_none() && file.seven_day.is_none() {

--- a/src/ui/quota.rs
+++ b/src/ui/quota.rs
@@ -103,11 +103,7 @@ fn draw_source_column(
     let ago_secs = rl.updated_at.map(|ts| now.saturating_sub(ts));
     let is_stale = ago_secs.is_some_and(|s| s > STALE_SECS);
 
-    let fresh_str = ago_secs.map(|ago| {
-        if ago < 60 { format!(" {}s ago", ago) }
-        else if ago < 3600 { format!(" {}m ago", ago / 60) }
-        else { format!(" {}h ago", ago / 3600) }
-    }).unwrap_or_default();
+    let fresh_str = ago_secs.map(format_ago).unwrap_or_default();
     let fresh_color = if is_stale { theme.inactive_fg } else { theme.graph_text };
 
     let mut lines: Vec<Line> = Vec::new();
@@ -146,6 +142,19 @@ fn draw_source_column(
     }
 
     f.render_widget(Paragraph::new(lines), area);
+}
+
+/// Format an "N ago" badge with auto-scaling unit (s → m → h → d).
+fn format_ago(secs: u64) -> String {
+    if secs < 60 {
+        format!(" {}s ago", secs)
+    } else if secs < 3600 {
+        format!(" {}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!(" {}h ago", secs / 3600)
+    } else {
+        format!(" {}d ago", secs / 86400)
+    }
 }
 
 /// Format a reset timestamp as relative time (e.g., "1h 23m")

--- a/src/ui/quota.rs
+++ b/src/ui/quota.rs
@@ -1,4 +1,5 @@
 use crate::app::App;
+use crate::model::RateLimitInfo;
 use crate::theme::Theme;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
@@ -8,10 +9,16 @@ use ratatui::Frame;
 
 use super::{btop_block, fmt_tokens, grad_at, make_gradient, remaining_bar, styled_label};
 
+/// Data considered "stale" when its updated_at is older than this many seconds.
+const STALE_SECS: u64 = 600;
+
+/// Fixed source order so columns stay stable across runs.
+const SOURCES: &[&str] = &["claude", "codex"];
+
 pub(crate) fn draw_quota_panel(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
     let cpu_grad = make_gradient(theme.cpu_grad.start, theme.cpu_grad.mid, theme.cpu_grad.end);
 
-    let block = btop_block("quota(left)", "²", theme.cpu_box, theme);
+    let block = btop_block("quota", "²", theme.cpu_box, theme);
     f.render_widget(block, area);
 
     let inner = Rect {
@@ -21,35 +28,20 @@ pub(crate) fn draw_quota_panel(f: &mut Frame, app: &App, area: Rect, theme: &The
         height: area.height.saturating_sub(2),
     };
 
-    let avail_h = inner.height as usize;
-
     // Bottom summary: total tokens + rate
     let total_tokens: u64 = app.sessions.iter().map(|s| s.total_tokens()).sum();
     let rates = &app.token_rates;
     let ticks_per_min = 30usize;
     let tokens_per_min: f64 = rates.iter().rev().take(ticks_per_min).sum();
-    if app.rate_limits.is_empty() {
-        let mut lines: Vec<Line> = Vec::new();
-        lines.push(Line::from(Span::styled(" QUOTA", Style::default().fg(theme.title).add_modifier(Modifier::BOLD))));
-        lines.push(Line::from(Span::styled("  — unavailable", Style::default().fg(theme.inactive_fg))));
-        lines.push(Line::from(Span::styled("  abtop --setup", Style::default().fg(theme.graph_text))));
-        while lines.len() < avail_h.saturating_sub(1) {
-            lines.push(Line::from(""));
-        }
-        lines.push(Line::from(vec![
-            Span::styled(format!(" {}", fmt_tokens(total_tokens)), Style::default().fg(theme.main_fg)),
-            Span::styled(format!(" {}/min", fmt_tokens(tokens_per_min as u64)), Style::default().fg(theme.graph_text)),
-        ]));
-        f.render_widget(Paragraph::new(lines), inner);
-        return;
-    }
 
-    // Split into side-by-side columns: one per rate limit source (CLAUDE | CODEX)
-    let num_sources = app.rate_limits.len().max(1) as u16;
+    // Split into side-by-side columns: one per known source (CLAUDE | CODEX).
+    // Columns are always rendered so the panel layout stays stable even when a
+    // source has no data yet.
+    let num_sources = SOURCES.len() as u16;
     let col_w = inner.width / num_sources;
     let content_h = inner.height.saturating_sub(1); // reserve last row for totals
 
-    for (i, rl) in app.rate_limits.iter().enumerate() {
+    for (i, source) in SOURCES.iter().enumerate() {
         let col_x = inner.x + (i as u16) * col_w;
         let this_w = if i as u16 == num_sources - 1 {
             inner.width - (i as u16) * col_w
@@ -57,47 +49,9 @@ pub(crate) fn draw_quota_panel(f: &mut Frame, app: &App, area: Rect, theme: &The
             col_w
         };
         let col_area = Rect { x: col_x, y: inner.y, width: this_w, height: content_h };
-        let col_w_usize = col_area.width as usize;
-        let bar_w = col_w_usize.saturating_sub(10).clamp(2, 8);
 
-        let mut lines: Vec<Line> = Vec::new();
-
-        // Source label with freshness
-        let fresh_str = rl.updated_at.map(|ts| {
-            let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
-            let ago = now.saturating_sub(ts);
-            if ago < 60 { format!(" {}s ago", ago) } else { format!(" {}m ago", ago / 60) }
-        }).unwrap_or_default();
-        let label = format!(" {}{}", rl.source.to_uppercase(), fresh_str);
-        lines.push(Line::from(Span::styled(label, Style::default().fg(theme.title).add_modifier(Modifier::BOLD))));
-
-        if let Some(used_pct) = rl.five_hour_pct {
-            let remaining = (100.0 - used_pct).clamp(0.0, 100.0);
-            let reset = rl.five_hour_resets_at.map(format_reset_time).unwrap_or_default();
-            // Color by urgency: low remaining = red (high used), high remaining = green
-            let c = grad_at(&cpu_grad, used_pct);
-            let mut s = vec![styled_label(" 5h ", theme.graph_text)];
-            s.extend(remaining_bar(remaining, bar_w, &cpu_grad, theme.meter_bg));
-            s.push(Span::styled(format!(" {:>3.0}%", remaining), Style::default().fg(c)));
-            lines.push(Line::from(s));
-            if !reset.is_empty() {
-                lines.push(Line::from(Span::styled(format!("  {}", reset), Style::default().fg(theme.graph_text))));
-            }
-        }
-        if let Some(used_pct) = rl.seven_day_pct {
-            let remaining = (100.0 - used_pct).clamp(0.0, 100.0);
-            let reset = rl.seven_day_resets_at.map(format_reset_time).unwrap_or_default();
-            let c = grad_at(&cpu_grad, used_pct);
-            let mut s = vec![styled_label(" 7d ", theme.graph_text)];
-            s.extend(remaining_bar(remaining, bar_w, &cpu_grad, theme.meter_bg));
-            s.push(Span::styled(format!(" {:>3.0}%", remaining), Style::default().fg(c)));
-            lines.push(Line::from(s));
-            if !reset.is_empty() {
-                lines.push(Line::from(Span::styled(format!("  {}", reset), Style::default().fg(theme.graph_text))));
-            }
-        }
-
-        f.render_widget(Paragraph::new(lines), col_area);
+        let rl = app.rate_limits.iter().find(|r| r.source.eq_ignore_ascii_case(source));
+        draw_source_column(f, col_area, source, rl, &cpu_grad, theme);
     }
 
     // Total tokens summary on last row (full width)
@@ -111,6 +65,87 @@ pub(crate) fn draw_quota_panel(f: &mut Frame, app: &App, area: Rect, theme: &The
         Span::styled(format!(" {}", fmt_tokens(total_tokens)), Style::default().fg(theme.main_fg)),
         Span::styled(format!(" {}/min", fmt_tokens(tokens_per_min as u64)), Style::default().fg(theme.graph_text)),
     ])]), bottom_area);
+}
+
+fn draw_source_column(
+    f: &mut Frame,
+    area: Rect,
+    source: &str,
+    rl: Option<&RateLimitInfo>,
+    cpu_grad: &[ratatui::style::Color; 101],
+    theme: &Theme,
+) {
+    let col_w_usize = area.width as usize;
+    let bar_w = col_w_usize.saturating_sub(10).clamp(2, 8);
+
+    let Some(rl) = rl else {
+        let hint = if source.eq_ignore_ascii_case("claude") {
+            "  abtop --setup"
+        } else {
+            "  run codex once"
+        };
+        let lines = vec![
+            Line::from(Span::styled(
+                format!(" {}", source.to_uppercase()),
+                Style::default().fg(theme.title).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled("  — no data", Style::default().fg(theme.inactive_fg))),
+            Line::from(Span::styled(hint, Style::default().fg(theme.graph_text))),
+        ];
+        f.render_widget(Paragraph::new(lines), area);
+        return;
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let ago_secs = rl.updated_at.map(|ts| now.saturating_sub(ts));
+    let is_stale = ago_secs.is_some_and(|s| s > STALE_SECS);
+
+    let fresh_str = ago_secs.map(|ago| {
+        if ago < 60 { format!(" {}s ago", ago) }
+        else if ago < 3600 { format!(" {}m ago", ago / 60) }
+        else { format!(" {}h ago", ago / 3600) }
+    }).unwrap_or_default();
+    let fresh_color = if is_stale { theme.inactive_fg } else { theme.graph_text };
+
+    let mut lines: Vec<Line> = Vec::new();
+    let mut label_spans = vec![Span::styled(
+        format!(" {}", rl.source.to_uppercase()),
+        Style::default().fg(theme.title).add_modifier(Modifier::BOLD),
+    )];
+    if !fresh_str.is_empty() {
+        label_spans.push(Span::styled(fresh_str, Style::default().fg(fresh_color)));
+    }
+    lines.push(Line::from(label_spans));
+
+    if let Some(used_pct) = rl.five_hour_pct {
+        let remaining = (100.0 - used_pct).clamp(0.0, 100.0);
+        let reset = rl.five_hour_resets_at.map(format_reset_time).unwrap_or_default();
+        let c = grad_at(cpu_grad, used_pct);
+        let mut s = vec![styled_label(" 5h ", theme.graph_text)];
+        s.extend(remaining_bar(remaining, bar_w, cpu_grad, theme.meter_bg));
+        s.push(Span::styled(format!(" {:>3.0}%", remaining), Style::default().fg(c)));
+        lines.push(Line::from(s));
+        if !reset.is_empty() {
+            lines.push(Line::from(Span::styled(format!("  {}", reset), Style::default().fg(theme.graph_text))));
+        }
+    }
+    if let Some(used_pct) = rl.seven_day_pct {
+        let remaining = (100.0 - used_pct).clamp(0.0, 100.0);
+        let reset = rl.seven_day_resets_at.map(format_reset_time).unwrap_or_default();
+        let c = grad_at(cpu_grad, used_pct);
+        let mut s = vec![styled_label(" 7d ", theme.graph_text)];
+        s.extend(remaining_bar(remaining, bar_w, cpu_grad, theme.meter_bg));
+        s.push(Span::styled(format!(" {:>3.0}%", remaining), Style::default().fg(c)));
+        lines.push(Line::from(s));
+        if !reset.is_empty() {
+            lines.push(Line::from(Span::styled(format!("  {}", reset), Style::default().fg(theme.graph_text))));
+        }
+    }
+
+    f.render_widget(Paragraph::new(lines), area);
 }
 
 /// Format a reset timestamp as relative time (e.g., "1h 23m")


### PR DESCRIPTION
## Summary

The quota panel dropped the Claude column when its data was older than 10 minutes, so only CODEX was shown and the block title said `quota(left)` (a leftover from an earlier split layout).

## Changes

- Always render both CLAUDE and CODEX columns so the panel layout stays stable.
- Each column shows its own freshness badge (`N s/m/h ago`) dimmed when older than 10 min.
- Source without a file gets a \`— no data / abtop --setup\` (or \`run codex once\`) hint instead of collapsing the layout.
- Remove the staleness rejection in \`read_rate_file\` — rate limits carry their own \`resets_at\` expiry and the UI already communicates freshness visually.
- Block title \`quota(left)\` → \`quota\`.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` — 35/35 pass
- [x] \`cargo run -- --once --demo\` renders
- [ ] Live: run with a fresh Claude file, wait >10 min, confirm column stays with dimmed timestamp
- [ ] Live: delete \`~/.claude/abtop-rate-limits.json\`, confirm placeholder shows \`abtop --setup\` hint