### PR TITLE
docs: update tagline from htop to btop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # abtop
 
-**Like htop, but for your AI coding agents.**
+**Like [btop](https://github.com/aristocratos/btop), but for your AI coding agents.**
 
 See every Claude Code and Codex CLI session at a glance — token usage, context window %, rate limits, child processes, open ports, and more.
 


### PR DESCRIPTION
## Summary

abtop's UI is inspired by [btop](https://github.com/aristocratos/btop) (panel layout, themes, box-drawing), not htop. Updates the README tagline to reflect this and links to the btop repo.