### PR TITLE
fix: exclude cache_creation from context window percentage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ Not provided in data files. Derive:
   - `claude-opus-4-6[1m]` → 1,000,000
   - `claude-sonnet-4-6` → 200,000
   - `claude-haiku-4-5` → 200,000
-- **Current usage**: last `assistant` line's `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
+- **Current usage**: last `assistant` line's `input_tokens + cache_read_input_tokens`. `cache_creation_input_tokens` is intentionally excluded — on compaction turns the same tokens can be reported as both `cache_creation` *and* `cache_read`, and summing all three double-counts (#54). Matches Claude Code's own statusline and the Codex collector.
 - **Percentage**: current_usage / window_size * 100
 - **Warning**: yellow at 80%, red at 90%, ⚠ icon at 90%+
 

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -706,9 +706,13 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
                                     result.total_output += out;
                                     result.total_cache_read += cr;
                                     result.total_cache_create += cc;
-                                    // Context = last turn's total input (this is what the model "sees")
+                                    // Context = what the model actually "sees" in its window:
+                                    // input_tokens (fresh) + cache_read (reused from cache).
+                                    // cache_creation is excluded — it's a write-side cost for
+                                    // future requests, not content in the current context window.
+                                    // Including it caused context_percent > 100% (#54).
                                     let prev_context = result.last_context_tokens;
-                                    result.last_context_tokens = inp + cr + cc;
+                                    result.last_context_tokens = inp + cr;
                                     if result.last_context_tokens > result.max_context_tokens {
                                         result.max_context_tokens = result.last_context_tokens;
                                     }
@@ -997,7 +1001,7 @@ mod tests {
         assert_eq!(result.total_cache_create, 30);
         assert_eq!(result.model, "claude-sonnet-4-6");
         assert_eq!(result.turn_count, 1);
-        assert_eq!(result.last_context_tokens, 330); // 100 + 200 + 30
+        assert_eq!(result.last_context_tokens, 300); // 100 + 200 (cache_creation excluded)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #54 - context percentage showing 346% on idle sessions.

## Root cause

`last_context_tokens` was computed as `input_tokens + cache_read + cache_creation`. The `cache_creation_input_tokens` field represents tokens written to the cache for **future** requests - it's not content in the current context window.

With heavy prompt caching, `cache_creation` can be very large (e.g. 150K tokens), causing the percentage to exceed 100%:

```
Before: (50K input + 150K cache_read + 150K cache_creation) / 200K window = 175%
After:  (50K input + 150K cache_read) / 200K window = 100%
```

## Fix

```diff
- result.last_context_tokens = inp + cr + cc;
+ result.last_context_tokens = inp + cr;
```

Context window = `input_tokens` (fresh) + `cache_read_input_tokens` (reused from cache). This matches what Claude Code's own statusline reports.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` - 35/35 pass (updated assertion in test_parse_transcript_basic_tokens)
- [x] Verified: Claude Code statusline shows 53% on the same session that abtop showed 346%