### PR TITLE
feat: add --exit-on-jump flag for tmux popup workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,7 @@ cargo build                    # Build
 cargo run                      # Run TUI
 cargo run -- --once            # Print snapshot and exit
 cargo run -- --setup           # Install StatusLine hook for rate limit collection
+cargo run -- --exit-on-jump    # Quit after Enter-jumping to a tmux pane (for popup overlays)
 cargo test                     # Tests
 cargo clippy                   # Lint
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,18 @@ fn sanitize_fallback(prompt: &str, max_len: usize) -> String {
     }
 }
 
+/// Outcome of an Enter-key jump attempt. Distinct from `Option<String>` so
+/// callers (notably `--exit-on-jump`) can tell a real tmux jump apart from
+/// a no-op (outside tmux, or empty session list).
+pub enum JumpOutcome {
+    /// Actually switched to a tmux pane.
+    Jumped,
+    /// Tried to jump in tmux but no pane owns the session's PID.
+    Failed(String),
+    /// Not in tmux, or nothing selected — nothing happened.
+    NoOp,
+}
+
 pub struct App {
     pub sessions: Vec<AgentSession>,
     pub selected: usize,
@@ -422,21 +434,19 @@ impl App {
     }
 
     /// Jump to the terminal running the selected session's Claude process.
-    /// In tmux: switch to the pane. Otherwise: show a helpful status message.
-    pub fn jump_to_session(&mut self) -> Option<String> {
+    /// In tmux: switch to the pane. Otherwise: no-op.
+    pub fn jump_to_session(&mut self) -> JumpOutcome {
         if self.sessions.is_empty() {
-            return None;
+            return JumpOutcome::NoOp;
         }
-        let session = &self.sessions[self.selected];
-        let target_pid = session.pid;
-
-        // tmux: actual jump
-        if std::env::var("TMUX").is_ok() {
-            return self.jump_via_tmux(target_pid);
+        if std::env::var("TMUX").is_err() {
+            return JumpOutcome::NoOp;
         }
-
-        // No tmux: no action
-        None
+        let target_pid = self.sessions[self.selected].pid;
+        match self.jump_via_tmux(target_pid) {
+            None => JumpOutcome::Jumped,
+            Some(msg) => JumpOutcome::Failed(msg),
+        }
     }
 
     fn jump_via_tmux(&self, target_pid: u32) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod setup;
 mod theme;
 mod ui;
 
-use app::App;
+use app::{App, JumpOutcome};
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::ExecutableCommand;
@@ -159,9 +159,9 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
                             KeyCode::Esc if !app.filter_text.is_empty() => app.clear_filter(),
                             KeyCode::Enter if !demo_mode => {
                                 match app.jump_to_session() {
-                                    None if exit_on_jump => app.quit(), // jump succeeded
-                                    Some(msg) => app.set_status(msg),  // jump failed
-                                    None => {}                         // success, keep running
+                                    JumpOutcome::Jumped if exit_on_jump => app.quit(),
+                                    JumpOutcome::Failed(msg) => app.set_status(msg),
+                                    JumpOutcome::Jumped | JumpOutcome::NoOp => {}
                                 }
                             },
                             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ fn main() -> io::Result<()> {
         });
 
     let demo_mode = std::env::args().any(|a| a == "--demo");
+    let exit_on_jump = std::env::args().any(|a| a == "--exit-on-jump");
 
     // --once flag: print snapshot and exit
     if std::env::args().any(|a| a == "--once") {
@@ -95,7 +96,7 @@ fn main() -> io::Result<()> {
     stdout().execute(EnterAlternateScreen)?;
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
 
-    let app_result = run_app(&mut terminal, demo_mode, initial_theme);
+    let app_result = run_app(&mut terminal, demo_mode, initial_theme, exit_on_jump);
 
     // Always attempt both cleanup steps regardless of app result
     let r1 = disable_raw_mode();
@@ -105,7 +106,7 @@ fn main() -> io::Result<()> {
     app_result.and(r1).and(r2)
 }
 
-fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: bool, initial_theme: Option<theme::Theme>) -> io::Result<()> {
+fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: bool, initial_theme: Option<theme::Theme>, exit_on_jump: bool) -> io::Result<()> {
     let mut app = App::new(initial_theme.unwrap_or_default());
     if demo_mode {
         demo::populate_demo(&mut app);
@@ -157,8 +158,10 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
                             KeyCode::Char('/') => app.filter_active = true,
                             KeyCode::Esc if !app.filter_text.is_empty() => app.clear_filter(),
                             KeyCode::Enter if !demo_mode => {
-                                if let Some(msg) = app.jump_to_session() {
-                                    app.set_status(msg);
+                                match app.jump_to_session() {
+                                    None if exit_on_jump => app.quit(), // jump succeeded
+                                    Some(msg) => app.set_status(msg),  // jump failed
+                                    None => {}                         // success, keep running
                                 }
                             },
                             _ => {}


### PR DESCRIPTION
## Summary

Closes #52 - adds `--exit-on-jump` flag that quits abtop after a successful Enter-jump to a tmux pane.

## Use case

```tmux
bind-key a display-popup -E -w 90% -h 90% "abtop --exit-on-jump"
```

Opens abtop as an ephemeral overlay. Press Enter on a session, abtop jumps to that pane and exits so the popup vanishes. Without the flag, default behavior is unchanged (abtop stays open).

## Implementation

Minimal change in `src/main.rs` (+7/-4 lines):
- Parse `--exit-on-jump` flag
- After successful Enter-jump (`jump_to_session()` returns `None`), call `app.quit()` instead of continuing

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` - 35/35 pass
- [x] Without flag: Enter-jump keeps abtop running (unchanged)
- [x] With flag: Enter-jump quits immediately after switching tmux pane