### PR TITLE
perf: replace lsof with /proc/pid/fd for Codex JSONL discovery

### DIFF
--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
+#[cfg(not(target_os = "linux"))]
 use std::process::Command;
 
 /// Collector for OpenAI Codex CLI sessions.
@@ -292,41 +293,72 @@ impl CodexCollector {
         pids
     }
 
-    /// Map codex PIDs to their open rollout-*.jsonl files via lsof.
+    /// Map codex PIDs to their open rollout-*.jsonl files.
+    ///
+    /// On Linux, scans /proc/{pid}/fd symlinks directly (no process spawn).
+    /// Falls back to lsof on other platforms.
     fn map_pid_to_jsonl(pids: &[u32]) -> HashMap<u32, PathBuf> {
         let mut map = HashMap::new();
         if pids.is_empty() {
             return map;
         }
 
-        // Build lsof command for all PIDs at once
-        let pid_args: Vec<String> = pids.iter().map(|p| format!("-p{}", p)).collect();
-        let mut args = vec!["-F", "pn"];
-        for pa in &pid_args {
-            args.push(pa);
-        }
-
-        let output = Command::new("lsof")
-            .args(&args)
-            .output()
-            .ok();
-
-        if let Some(output) = output {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let mut current_pid: Option<u32> = None;
-            for line in stdout.lines() {
-                if let Some(pid_str) = line.strip_prefix('p') {
-                    current_pid = pid_str.parse::<u32>().ok();
-                } else if let Some(name) = line.strip_prefix('n') {
-                    if let Some(pid) = current_pid {
-                        if name.contains("rollout-") && name.ends_with(".jsonl") {
-                            map.insert(pid, PathBuf::from(name));
+        #[cfg(target_os = "linux")]
+        {
+            for &pid in pids {
+                let fd_dir = format!("/proc/{}/fd", pid);
+                let entries = match fs::read_dir(&fd_dir) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+                for entry in entries.flatten() {
+                    if let Ok(target) = fs::read_link(entry.path()) {
+                        // Match on the file name component to avoid lossy UTF-8
+                        // conversion issues on the full path.
+                        let is_rollout = target.file_name()
+                            .and_then(|n| n.to_str())
+                            .is_some_and(|n| n.starts_with("rollout-") && n.ends_with(".jsonl"));
+                        if is_rollout {
+                            map.insert(pid, target);
+                            break;
                         }
                     }
                 }
             }
+            map
         }
-        map
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            // Fallback: lsof on macOS and other platforms
+            let pid_args: Vec<String> = pids.iter().map(|p| format!("-p{}", p)).collect();
+            let mut args = vec!["-F", "pn"];
+            for pa in &pid_args {
+                args.push(pa);
+            }
+
+            let output = Command::new("lsof")
+                .args(&args)
+                .output()
+                .ok();
+
+            if let Some(output) = output {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let mut current_pid: Option<u32> = None;
+                for line in stdout.lines() {
+                    if let Some(pid_str) = line.strip_prefix('p') {
+                        current_pid = pid_str.parse::<u32>().ok();
+                    } else if let Some(name) = line.strip_prefix('n') {
+                        if let Some(pid) = current_pid {
+                            if name.contains("rollout-") && name.ends_with(".jsonl") {
+                                map.insert(pid, PathBuf::from(name));
+                            }
+                        }
+                    }
+                }
+            }
+            map
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

On Linux, scan `/proc/{pid}/fd` symlinks directly to find open `rollout-*.jsonl` files instead of spawning `lsof`. Eliminates one fork+exec per tick (~400 syscalls, ~10-30ms) when Codex sessions are active.

Falls back to `lsof` on macOS where `/proc` is not available.

## Before/After

| | Before | After (Linux) |
|--|--------|---------------|
| Method | `Command::new("lsof").args(["-F", "pn", "-p{pid}"])` | `fs::read_dir("/proc/{pid}/fd")` + `read_link` |
| Cost | fork+exec+parse (~10-30ms, ~400 syscalls) | ~20 readlink() calls (~0.1ms) |
| Platform | All | Linux native, macOS fallback to lsof |

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` - 35/35 pass
- [x] macOS fallback preserved via `#[cfg(not(target_os = "linux"))]`
- [x] Path matching uses `file_name().to_str()` instead of `to_string_lossy()` for correctness on non-UTF8 paths