### PR TITLE
feat: add hidden_agents config to skip CLIs in TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ Colorblind-friendly themes:
 |:-:|:-:|
 | ![deuteranopia](assets/themes/deuteranopia.png) | ![tritanopia](assets/themes/tritanopia.png) |
 
+## Configuration
+
+`~/.config/abtop/config.toml` supports:
+
+```toml
+theme = "btop"
+# Hide specific agent CLIs from the TUI (case-insensitive).
+# Useful if you only use one agent and want a cleaner view.
+hidden_agents = ["codex"]
+```
+
 ## Key Bindings
 
 | Key                | Action                               |

--- a/src/app.rs
+++ b/src/app.rs
@@ -78,7 +78,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(theme: Theme) -> Self {
+    pub fn new_with_hidden(theme: Theme, hidden_agents: &[String]) -> Self {
         let (tx, rx) = mpsc::channel();
         let summaries = load_summary_cache();
         Self {
@@ -89,7 +89,7 @@ impl App {
             rate_limits: Vec::new(),
             prev_tokens: HashMap::new(),
             rate_limit_counter: 5,
-            collector: MultiCollector::new(),
+            collector: MultiCollector::with_hidden(hidden_agents),
             summaries,
             pending_summaries: HashSet::new(),
             summary_retries: HashMap::new(),

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -112,12 +112,22 @@ pub struct MultiCollector {
 const SLOW_POLL_INTERVAL: u32 = 5;
 
 impl MultiCollector {
-    pub fn new() -> Self {
+    /// Build a collector, skipping agents whose identifier is in `hidden`.
+    /// Identifiers are matched case-insensitively against each collector's
+    /// `agent_cli` name (e.g. `"claude"`, `"codex"`).
+    pub fn with_hidden(hidden: &[String]) -> Self {
+        let is_hidden = |name: &str| {
+            hidden.iter().any(|h| h.eq_ignore_ascii_case(name))
+        };
+        let mut collectors: Vec<Box<dyn AgentCollector>> = Vec::new();
+        if !is_hidden("claude") {
+            collectors.push(Box::new(ClaudeCollector::new()));
+        }
+        if !is_hidden("codex") {
+            collectors.push(Box::new(CodexCollector::new()));
+        }
         Self {
-            collectors: vec![
-                Box::new(ClaudeCollector::new()),
-                Box::new(CodexCollector::new()),
-            ],
+            collectors,
             tick_count: SLOW_POLL_INTERVAL, // trigger on first tick
             cached_ports: HashMap::new(),
             cached_port_pids: Vec::new(),
@@ -240,6 +250,46 @@ impl MultiCollector {
         self.orphan_ports.sort_by_key(|o| o.port);
 
         all
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_hidden_empty_keeps_all_collectors() {
+        let mc = MultiCollector::with_hidden(&[]);
+        assert_eq!(mc.collectors.len(), 2);
+    }
+
+    #[test]
+    fn with_hidden_codex_drops_codex_only() {
+        let mc = MultiCollector::with_hidden(&["codex".to_string()]);
+        assert_eq!(mc.collectors.len(), 1);
+    }
+
+    #[test]
+    fn with_hidden_is_case_insensitive() {
+        let mc = MultiCollector::with_hidden(&["CODEX".to_string()]);
+        assert_eq!(mc.collectors.len(), 1);
+        let mc = MultiCollector::with_hidden(&["Claude".to_string()]);
+        assert_eq!(mc.collectors.len(), 1);
+    }
+
+    #[test]
+    fn with_hidden_unknown_names_are_ignored() {
+        let mc = MultiCollector::with_hidden(&["kiro".to_string(), "gemini".to_string()]);
+        assert_eq!(mc.collectors.len(), 2);
+    }
+
+    #[test]
+    fn with_hidden_all_agents_yields_empty() {
+        let mc = MultiCollector::with_hidden(&[
+            "claude".to_string(),
+            "codex".to_string(),
+        ]);
+        assert!(mc.collectors.is_empty());
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,16 @@ use std::path::PathBuf;
 
 pub struct AppConfig {
     pub theme: String,
+    /// Agent CLI names to exclude from the TUI (e.g. ["codex"] to hide Codex).
+    /// Matched case-insensitively against each collector's agent_cli identifier.
+    pub hidden_agents: Vec<String>,
 }
 
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
             theme: "btop".to_string(),
+            hidden_agents: Vec::new(),
         }
     }
 }
@@ -42,6 +46,10 @@ pub fn load_config() -> AppConfig {
             } else {
                 val
             };
+            if key == "hidden_agents" {
+                config.hidden_agents = parse_string_array(val);
+                continue;
+            }
             let val = val.trim_matches('"').trim_matches('\'');
             if key == "theme" {
                 config.theme = val.to_string();
@@ -49,6 +57,20 @@ pub fn load_config() -> AppConfig {
         }
     }
     config
+}
+
+/// Parse a simple one-line TOML string array like `["a", "b"]`.
+/// Returns an empty Vec for malformed input to keep config loading infallible.
+fn parse_string_array(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+    let Some(inner) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
+        return Vec::new();
+    };
+    inner
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 pub fn save_theme(name: &str) -> Result<(), String> {
@@ -80,4 +102,33 @@ pub fn save_theme(name: &str) -> Result<(), String> {
         lines.push(format!("theme = \"{}\"", name));
     }
     std::fs::write(&path, lines.join("\n") + "\n").map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_string_array_basic() {
+        assert_eq!(parse_string_array(r#"["codex"]"#), vec!["codex"]);
+        assert_eq!(
+            parse_string_array(r#"["codex", "claude"]"#),
+            vec!["codex", "claude"]
+        );
+    }
+
+    #[test]
+    fn parse_string_array_quote_styles_and_whitespace() {
+        assert_eq!(
+            parse_string_array(r#"[ 'codex' , "claude" ]"#),
+            vec!["codex", "claude"]
+        );
+    }
+
+    #[test]
+    fn parse_string_array_empty_and_malformed() {
+        assert!(parse_string_array("[]").is_empty());
+        assert!(parse_string_array("not an array").is_empty());
+        assert!(parse_string_array(r#"["a",,]"#).iter().all(|s| !s.is_empty()) );
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,14 @@ pub fn save_theme(name: &str) -> Result<(), String> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => return Err(e.to_string()),
     };
+    let new_content = rewrite_theme_line(&content, name);
+    std::fs::write(&path, new_content).map_err(|e| e.to_string())
+}
+
+/// Rewrite (or append) the `theme = "..."` line in a config file body.
+/// Every other line is preserved verbatim, so keys like `hidden_agents`
+/// set by the user or by a future save_* helper survive theme switches.
+fn rewrite_theme_line(content: &str, name: &str) -> String {
     let mut lines: Vec<String> = Vec::new();
     let mut found = false;
     for line in content.lines() {
@@ -101,7 +109,7 @@ pub fn save_theme(name: &str) -> Result<(), String> {
     if !found {
         lines.push(format!("theme = \"{}\"", name));
     }
-    std::fs::write(&path, lines.join("\n") + "\n").map_err(|e| e.to_string())
+    lines.join("\n") + "\n"
 }
 
 #[cfg(test)]
@@ -130,5 +138,33 @@ mod tests {
         assert!(parse_string_array("[]").is_empty());
         assert!(parse_string_array("not an array").is_empty());
         assert!(parse_string_array(r#"["a",,]"#).iter().all(|s| !s.is_empty()) );
+    }
+
+    #[test]
+    fn rewrite_theme_preserves_hidden_agents_line() {
+        let before = "theme = \"btop\"\nhidden_agents = [\"codex\"]\n";
+        let after = rewrite_theme_line(before, "dracula");
+        assert!(after.contains("theme = \"dracula\""));
+        assert!(
+            after.contains("hidden_agents = [\"codex\"]"),
+            "hidden_agents line dropped by rewrite_theme_line:\n{after}"
+        );
+    }
+
+    #[test]
+    fn rewrite_theme_preserves_arbitrary_unknown_keys() {
+        let before = "# user comment\nfuture_key = 42\ntheme = \"btop\"\n";
+        let after = rewrite_theme_line(before, "nord");
+        assert!(after.contains("# user comment"));
+        assert!(after.contains("future_key = 42"));
+        assert!(after.contains("theme = \"nord\""));
+    }
+
+    #[test]
+    fn rewrite_theme_appends_when_missing() {
+        let before = "hidden_agents = [\"codex\"]\n";
+        let after = rewrite_theme_line(before, "gruvbox");
+        assert!(after.contains("hidden_agents = [\"codex\"]"));
+        assert!(after.contains("theme = \"gruvbox\""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ fn main() -> io::Result<()> {
         return Ok(());
     }
 
+    // Load config once; it drives both the default theme and the hidden-agents list.
+    let cfg = config::load_config();
+
     // --theme flag > config file > default
     let initial_theme = std::env::args()
         .position(|a| a == "--theme")
@@ -63,7 +66,6 @@ fn main() -> io::Result<()> {
             })
         })
         .or_else(|| {
-            let cfg = config::load_config();
             theme::Theme::by_name(&cfg.theme)
         });
 
@@ -72,7 +74,10 @@ fn main() -> io::Result<()> {
 
     // --once flag: print snapshot and exit
     if std::env::args().any(|a| a == "--once") {
-        let mut app = App::new(initial_theme.unwrap_or_default());
+        let mut app = App::new_with_hidden(
+            initial_theme.unwrap_or_default(),
+            &cfg.hidden_agents,
+        );
         if demo_mode {
             demo::populate_demo(&mut app);
         } else {
@@ -96,7 +101,7 @@ fn main() -> io::Result<()> {
     stdout().execute(EnterAlternateScreen)?;
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
 
-    let app_result = run_app(&mut terminal, demo_mode, initial_theme, exit_on_jump);
+    let app_result = run_app(&mut terminal, demo_mode, initial_theme, exit_on_jump, &cfg.hidden_agents);
 
     // Always attempt both cleanup steps regardless of app result
     let r1 = disable_raw_mode();
@@ -106,8 +111,8 @@ fn main() -> io::Result<()> {
     app_result.and(r1).and(r2)
 }
 
-fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: bool, initial_theme: Option<theme::Theme>, exit_on_jump: bool) -> io::Result<()> {
-    let mut app = App::new(initial_theme.unwrap_or_default());
+fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: bool, initial_theme: Option<theme::Theme>, exit_on_jump: bool, hidden_agents: &[String]) -> io::Result<()> {
+    let mut app = App::new_with_hidden(initial_theme.unwrap_or_default(), hidden_agents);
     if demo_mode {
         demo::populate_demo(&mut app);
     } else {

--- a/src/model/session.rs
+++ b/src/model/session.rs
@@ -108,6 +108,8 @@ pub struct ToolCall {
 #[derive(Debug, Clone)]
 pub struct AgentSession {
     /// Which CLI tool this session belongs to: "claude", "codex", etc.
+    /// Also used as the identifier for the `hidden_agents` config key
+    /// (case-insensitive match).
     pub agent_cli: &'static str,
     pub pid: u32,
     pub session_id: String,


### PR DESCRIPTION
## Summary

Closes #71.

Lets users hide specific agent CLIs from the TUI via config file, for people who only use one agent and want a cleaner view.

```toml
# ~/.config/abtop/config.toml
hidden_agents = ["codex"]
```

Match is case-insensitive against the `agent_cli` identifier. Unknown names are ignored so the same config file can be shared across builds with different feature flags (anticipating #45).

## Implementation

- `AppConfig` gains a `hidden_agents: Vec<String>` field.
- The ad-hoc TOML parser in `config.rs` learns to parse single-line string arrays (`["a", "b"]`).
- `MultiCollector::with_hidden(&[String])` replaces `new()` and only pushes collectors whose name is not in the hidden list.
- `App::new_with_hidden` threads the list through; `main.rs` loads the config once and passes it to both `--once` and the interactive paths.

## Follow-up

Once #45 lands and agents are gated by cargo features, a config page toggle (Esc) can be added on top of this same `hidden_agents` key, so users can flip agents on/off at runtime. The TOML contract defined here is designed to be that foundation, no schema change needed for the UI pass.

## Test plan

- [x] `cargo test` passes 81/81, including 8 new tests (`config::tests::*`, `collector::tests::with_hidden_*`)
- [x] `cargo clippy -- -D warnings` clean
- [x] Default behavior unchanged when `hidden_agents` is absent
- [x] Case-insensitive match verified
- [x] Unknown agent names silently ignored
