### PR TITLE
fix: trigger crates.io publish on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish to crates.io
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary

`publish.yml` uses `on: release: types: [published]`, but this event does not fire for GitHub Releases created with the default `GITHUB_TOKEN` in Actions. Since `cargo-dist`'s `release.yml` creates Releases with `GITHUB_TOKEN`, `publish.yml` has not run since v0.2.3 — v0.3.0 through v0.3.6 all shipped binaries via GitHub Releases but never reached crates.io, leaving `cargo install abtop` stuck at 0.2.3.

Switch to a tag-push trigger using the same pattern `release.yml` uses. The two workflows run in parallel; `cargo publish` is independent of the GitHub Release so ordering doesn't matter.

## Test plan

- [ ] Merge this PR
- [ ] Tag `v0.3.7` and confirm both Release and Publish workflows trigger
- [ ] Verify 0.3.7 appears on crates.io

(0.3.6 will be manually published separately to close the gap.)