### PR TITLE
fix: exclude assets/ from cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["tui", "monitor", "claude", "ai", "agent"]
 categories = ["command-line-utilities"]
 readme = "README.md"
 authors = ["Tae Hwan Jung <nlkey2022@gmail.com>"]
+exclude = ["assets/*", "assets/**/*"]
 
 [dependencies]
 ratatui = "0.29"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 See every Claude Code and Codex CLI session at a glance — token usage, context window %, rate limits, child processes, open ports, and more.
 Claude Code and Codex CLI sessions are discovered from local process/file state, so multiple active profiles are supported across macOS and Linux.
 
-![demo](assets/demo.gif)
+![demo](https://raw.githubusercontent.com/graykode/abtop/main/assets/demo.gif)
 
 ## Why
 
@@ -89,21 +89,21 @@ tmux new -s work
 
 | btop (default) | dracula | catppuccin |
 |:-:|:-:|:-:|
-| ![btop](assets/themes/btop.png) | ![dracula](assets/themes/dracula.png) | ![catppuccin](assets/themes/catppuccin.png) |
+| ![btop](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/btop.png) | ![dracula](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/dracula.png) | ![catppuccin](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/catppuccin.png) |
 
 | tokyo-night | gruvbox | nord |
 |:-:|:-:|:-:|
-| ![tokyo-night](assets/themes/tokyo-night.png) | ![gruvbox](assets/themes/gruvbox.png) | ![nord](assets/themes/nord.png) |
+| ![tokyo-night](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/tokyo-night.png) | ![gruvbox](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/gruvbox.png) | ![nord](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/nord.png) |
 
 Colorblind-friendly themes:
 
 | high-contrast | protanopia |
 |:-:|:-:|
-| ![high-contrast](assets/themes/high-contrast.png) | ![protanopia](assets/themes/protanopia.png) |
+| ![high-contrast](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/high-contrast.png) | ![protanopia](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/protanopia.png) |
 
 | deuteranopia | tritanopia |
 |:-:|:-:|
-| ![deuteranopia](assets/themes/deuteranopia.png) | ![tritanopia](assets/themes/tritanopia.png) |
+| ![deuteranopia](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/deuteranopia.png) | ![tritanopia](https://raw.githubusercontent.com/graykode/abtop/main/assets/themes/tritanopia.png) |
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

The demo gifs and theme screenshots under `assets/` total ~13 MiB uncompressed, which exceeds crates.io's 10 MiB per-crate upload limit. This is why the manual `cargo publish` attempt after #76 failed with `413 Payload Too Large`.

Exclude `assets/` from the cargo package and rewrite README image links to absolute `raw.githubusercontent.com` URLs, so:
- the package ships at ~107 KiB compressed (well under the limit),
- the README still renders images correctly both on GitHub and on crates.io.

## Verified

- `cargo package --list` no longer includes any `assets/*` entries
- `target/package/abtop-0.3.6.crate` is 107 KiB (was ~13 MiB)
- All 11 README image references rewritten to absolute URLs in one sweep

## Follow-up

Once this lands, 0.3.6 can be manually published to close the `0.2.3 → 0.3.7` gap (or we skip 0.3.6 on crates.io entirely and let #76's automation publish the next tag).