### PR TITLE
fix(input): close config overlay on second 'c' press

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
                         }
                     } else if app.config_open {
                         match key.code {
-                            KeyCode::Esc | KeyCode::Char('q') => app.toggle_config(),
+                            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('c') => app.toggle_config(),
                             KeyCode::Down | KeyCode::Char('j') => app.config_select_next(),
                             KeyCode::Up | KeyCode::Char('k') => app.config_select_prev(),
                             KeyCode::Enter | KeyCode::Char(' ') => app.config_toggle_selected(),


### PR DESCRIPTION
Noticed c opens the config overlay but a second press of c doesn't close it, you have to hit Esc or q. Both ? and v already toggle on the same key, so adding c to the close arm keeps it consistent.

One-liner in the config_open match.