### PR TITLE
feat: add Windows platform support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
 ]
 
@@ -120,6 +121,31 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -300,7 +326,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -459,6 +485,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +605,26 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -774,6 +829,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,16 +1042,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -990,6 +1092,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1012,6 +1125,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ dirs = "6"
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 
+[target.'cfg(windows)'.dependencies]
+sysinfo = "0.32"
+
 [target.'cfg(target_vendor = "apple")'.dependencies]
 proc_pidinfo = "0.1"
 

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -7,7 +7,7 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
-#[cfg(all(not(target_os = "linux"), not(target_vendor = "apple")))]
+#[cfg(all(not(target_os = "linux"), not(target_vendor = "apple"), not(target_os = "windows")))]
 use std::process::Command;
 
 /// A single Claude config directory (sessions + projects + transcripts).
@@ -244,7 +244,12 @@ impl ClaudeCollector {
             map_pid_to_libproc_open_paths(pids)
         }
 
-        #[cfg(all(not(target_os = "linux"), not(target_vendor = "apple")))]
+        #[cfg(target_os = "windows")]
+        {
+            map_pid_to_sysinfo_open_paths(pids)
+        }
+
+        #[cfg(all(not(target_os = "linux"), not(target_vendor = "apple"), not(target_os = "windows")))]
         {
             map_pid_to_lsof_open_paths(pids)
         }
@@ -776,7 +781,36 @@ fn map_pid_to_libproc_open_paths(pids: &[u32]) -> HashMap<u32, ProcessOpenPaths>
     map
 }
 
-#[cfg(all(not(target_os = "linux"), not(target_vendor = "apple")))]
+#[cfg(target_os = "windows")]
+fn map_pid_to_sysinfo_open_paths(pids: &[u32]) -> HashMap<u32, ProcessOpenPaths> {
+    use sysinfo::{System, ProcessRefreshKind, ProcessesToUpdate};
+
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::everything()
+    );
+
+    let mut map = HashMap::new();
+    let pid_set: std::collections::HashSet<u32> = pids.iter().copied().collect();
+
+    for (pid, proc) in sys.processes() {
+        let pid_u32 = pid.as_u32();
+        if !pid_set.contains(&pid_u32) {
+            continue;
+        }
+
+        let cwd: Option<PathBuf> = proc.cwd().map(|p| p.to_path_buf());
+        // sysinfo 0.32 doesn't have fd_list, use empty paths list
+        // open file tracking is less critical - discovery via session files works
+        map.insert(pid_u32, ProcessOpenPaths { cwd, paths: Vec::new() });
+    }
+
+    map
+}
+
+#[cfg(all(not(target_os = "linux"), not(target_vendor = "apple"), not(target_os = "windows")))]
 fn map_pid_to_lsof_open_paths(pids: &[u32]) -> HashMap<u32, ProcessOpenPaths> {
     let pid_args: Vec<String> = pids.iter().map(|p| format!("-p{}", p)).collect();
     let mut args = vec!["-F", "ftn"];
@@ -790,7 +824,7 @@ fn map_pid_to_lsof_open_paths(pids: &[u32]) -> HashMap<u32, ProcessOpenPaths> {
         .unwrap_or_default()
 }
 
-#[cfg_attr(any(target_os = "linux", target_vendor = "apple"), allow(dead_code))]
+#[cfg_attr(any(target_os = "linux", target_vendor = "apple", target_os = "windows"), allow(dead_code))]
 fn parse_lsof_process_info(output: &str) -> HashMap<u32, ProcessOpenPaths> {
     let mut map: HashMap<u32, ProcessOpenPaths> = HashMap::new();
     let mut current_pid: Option<u32> = None;
@@ -1097,6 +1131,7 @@ fn is_symlink(path: &Path) -> bool {
 }
 
 /// Get file identity as (inode, mtime_nanos) for detecting file replacement.
+#[cfg(unix)]
 fn file_identity(path: &Path) -> (u64, u64) {
     fs::metadata(path)
         .ok()
@@ -1109,6 +1144,24 @@ fn file_identity(path: &Path) -> (u64, u64) {
                 .map(|d| d.as_nanos() as u64)
                 .unwrap_or(0);
             (ino, mtime_ns)
+        })
+        .unwrap_or((0, 0))
+}
+
+/// Windows fallback: use file size + mtime as identity
+#[cfg(windows)]
+fn file_identity(path: &Path) -> (u64, u64) {
+    fs::metadata(path)
+        .ok()
+        .map(|m| {
+            let size = m.len();
+            let mtime_ns = m
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_nanos() as u64)
+                .unwrap_or(0);
+            (size, mtime_ns)
         })
         .unwrap_or((0, 0))
 }

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -101,7 +101,7 @@ pub fn get_process_info() -> HashMap<u32, ProcInfo> {
     map
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 pub fn get_process_info() -> HashMap<u32, ProcInfo> {
     let mut map = HashMap::new();
     let output = Command::new("ps")
@@ -131,6 +131,42 @@ pub fn get_process_info() -> HashMap<u32, ProcInfo> {
                 }
             }
         }
+    }
+    map
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_process_info() -> HashMap<u32, ProcInfo> {
+    use sysinfo::{System, ProcessRefreshKind, ProcessesToUpdate};
+
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::everything()
+    );
+
+    let mut map = HashMap::new();
+    for (pid, proc) in sys.processes() {
+        let pid_u32 = pid.as_u32();
+        // On Windows, cmd() may be empty but name() has the executable
+        let cmd: Vec<String> = proc.cmd().iter().map(|s| s.to_string_lossy().into_owned()).collect();
+        let command = if cmd.is_empty() {
+            // Use name() as fallback when cmdline is empty
+            proc.name().to_string_lossy().into_owned()
+        } else {
+            cmd.join(" ")
+        };
+        if command.is_empty() {
+            continue;
+        }
+        map.insert(pid_u32, ProcInfo {
+            pid: pid_u32,
+            ppid: proc.parent().map(|p| p.as_u32()).unwrap_or(0),
+            rss_kb: proc.memory() / 1024,
+            cpu_pct: proc.cpu_usage() as f64,
+            command,
+        });
     }
     map
 }
@@ -228,7 +264,7 @@ pub fn get_listening_ports() -> HashMap<u32, Vec<u16>> {
     map
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 pub fn get_listening_ports() -> HashMap<u32, Vec<u16>> {
     let mut map: HashMap<u32, Vec<u16>> = HashMap::new();
     let output = Command::new("lsof")
@@ -258,14 +294,44 @@ pub fn get_listening_ports() -> HashMap<u32, Vec<u16>> {
     map
 }
 
+#[cfg(target_os = "windows")]
+pub fn get_listening_ports() -> HashMap<u32, Vec<u16>> {
+    let mut map: HashMap<u32, Vec<u16>> = HashMap::new();
+
+    let output = Command::new("netstat")
+        .args(["-ano"])
+        .output()
+        .ok();
+
+    if let Some(output) = output {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines().skip(4) {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 5 && parts[0] == "TCP" && parts[3] == "LISTENING" {
+                let addr = parts[1];
+                if let Some(port_str) = addr.rsplit(':').next() {
+                    if let Ok(port) = port_str.parse::<u16>() {
+                        if let Ok(pid) = parts[4].parse::<u32>() {
+                            map.entry(pid).or_default().push(port);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    map
+}
+
 /// Check if a command string has a given binary name in executable position.
 /// Checks the first two argv tokens only (covers direct invocation and
 /// interpreter-wrapped scripts like `node /path/to/codex ...`).
+/// Also accepts process name on Windows when command is empty.
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     let mut tokens = cmd.split_whitespace().take(2);
     tokens.any(|tok| {
-        let base = tok.rsplit('/').next().unwrap_or(tok);
-        base == name
+        let base = tok.rsplit(|c| c == '/' || c == '\\').next().unwrap_or(tok);
+        let base = base.strip_suffix(".exe").unwrap_or(base);
+        base.eq_ignore_ascii_case(name)
     })
 }
 


### PR DESCRIPTION
## Summary

- Add sysinfo crate for Windows process info collection
- Implement map_pid_to_sysinfo_open_paths using sysinfo
- Implement get_process_info using sysinfo on Windows
- Implement get_listening_ports using netstat on Windows
- Add Windows-specific file_identity using size+mtime
- Fix cmd_has_binary to handle Windows paths and .exe suffix

## Test plan

- [x] Build on Windows with cargo build
- [x] Run abtop and verify process detection works
- [ ] Test session discovery with Claude Code on Windows
- [ ] Test port detection