### PR TITLE
feat: support multiple Claude Code quota sources

### DIFF
--- a/scripts/abtop-statusline.sh
+++ b/scripts/abtop-statusline.sh
@@ -7,23 +7,32 @@
 #
 # Or run: abtop --setup
 
-OUTPUT_FILE="$HOME/.claude/abtop-rate-limits.json"
-
 # Read JSON from stdin
 input=$(cat)
+
+transcript_path=""
+if command -v jq &>/dev/null; then
+    transcript_path=$(echo "$input" | jq -r '.transcript_path // empty' 2>/dev/null)
+fi
+if [[ "$transcript_path" == */projects/* ]]; then
+    CONFIG_DIR="${transcript_path%%/projects/*}"
+else
+    CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+fi
+OUTPUT_FILE="$CONFIG_DIR/abtop-rate-limits.json"
 
 # Extract rate_limits using python/jq/node (whichever is available)
 if command -v python3 &>/dev/null; then
     echo "$input" | python3 -c "
-import sys, json, time
+import sys, json, time, os
 try:
     data = json.load(sys.stdin)
     rl = data.get('rate_limits', {})
     if not rl:
         sys.exit(0)
     out = {'source': 'claude', 'updated_at': int(time.time())}
-    session = rl.get('session', {})
-    weekly = rl.get('weekly', {})
+    session = rl.get('five_hour') or rl.get('session') or {}
+    weekly = rl.get('seven_day') or rl.get('weekly') or {}
     if session:
         out['five_hour'] = {
             'used_percentage': session.get('used_percentage', 0),
@@ -34,20 +43,43 @@ try:
             'used_percentage': weekly.get('used_percentage', 0),
             'resets_at': weekly.get('resets_at', 0)
         }
-    with open('$OUTPUT_FILE', 'w') as f:
+    if 'five_hour' not in out and 'seven_day' not in out:
+        sys.exit(0)
+    config_dir = None
+    transcript_path = data.get('transcript_path')
+    if transcript_path:
+        p = os.path.abspath(transcript_path)
+        parts = p.split(os.sep)
+        if 'projects' in parts:
+            idx = parts.index('projects')
+            inferred = os.sep.join(parts[:idx])
+            if inferred:
+                config_dir = inferred
+    if not config_dir:
+        config_dir = os.environ.get('CLAUDE_CONFIG_DIR')
+    if not config_dir:
+        config_dir = os.path.join(os.path.expanduser('~'), '.claude')
+    path = os.path.join(config_dir, 'abtop-rate-limits.json')
+    os.makedirs(config_dir, exist_ok=True)
+    tmp = path + '.tmp'
+    with open(tmp, 'w') as f:
         json.dump(out, f)
+    os.replace(tmp, path)
 except Exception:
     pass
 "
 elif command -v jq &>/dev/null; then
-    five_pct=$(echo "$input" | jq -r '.rate_limits.session.used_percentage // empty' 2>/dev/null)
+    five_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // .rate_limits.session.used_percentage // empty' 2>/dev/null)
     if [ -n "$five_pct" ]; then
-        five_reset=$(echo "$input" | jq -r '.rate_limits.session.resets_at // 0')
-        seven_pct=$(echo "$input" | jq -r '.rate_limits.weekly.used_percentage // 0')
-        seven_reset=$(echo "$input" | jq -r '.rate_limits.weekly.resets_at // 0')
+        five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // .rate_limits.session.resets_at // 0')
+        seven_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // .rate_limits.weekly.used_percentage // 0')
+        seven_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // .rate_limits.weekly.resets_at // 0')
         now=$(date +%s)
-        cat > "$OUTPUT_FILE" <<EOF
+        mkdir -p "$CONFIG_DIR"
+        tmp="$OUTPUT_FILE.tmp"
+        cat > "$tmp" <<EOF
 {"source":"claude","updated_at":$now,"five_hour":{"used_percentage":$five_pct,"resets_at":$five_reset},"seven_day":{"used_percentage":$seven_pct,"resets_at":$seven_reset}}
 EOF
+        mv "$tmp" "$OUTPUT_FILE"
     fi
 fi

--- a/src/app.rs
+++ b/src/app.rs
@@ -757,7 +757,7 @@ fn promote_waiting_to_rate_limited(
             continue;
         }
         let over = rate_limits.iter().any(|rl| {
-            rl.source == s.agent_cli
+            rate_limit_source_matches_agent(&rl.source, s.agent_cli)
                 && (rl.five_hour_pct.unwrap_or(0.0) > RATE_LIMITED_PCT
                     || rl.seven_day_pct.unwrap_or(0.0) > RATE_LIMITED_PCT)
         });
@@ -765,6 +765,19 @@ fn promote_waiting_to_rate_limited(
             s.status = SessionStatus::RateLimited;
         }
     }
+}
+
+fn rate_limit_source_matches_agent(source: &str, agent_cli: &str) -> bool {
+    if source.eq_ignore_ascii_case(agent_cli) {
+        return true;
+    }
+
+    if !agent_cli.eq_ignore_ascii_case("claude") {
+        return false;
+    }
+
+    let source = source.to_ascii_lowercase();
+    source.starts_with("claude-")
 }
 
 #[cfg(test)]
@@ -839,6 +852,15 @@ mod tests {
         let limits = vec![rate_limit("claude", 89.9)];
         promote_waiting_to_rate_limited(&mut sessions, &limits);
         assert_eq!(sessions[0].status, SessionStatus::Waiting);
+    }
+
+    #[test]
+    fn test_rate_limited_promotion_matches_profiled_claude_sources() {
+        let mut sessions = vec![waiting_session("claude"), waiting_session("codex")];
+        let limits = vec![rate_limit("claude-work", 95.0)];
+        promote_waiting_to_rate_limited(&mut sessions, &limits);
+        assert_eq!(sessions[0].status, SessionStatus::RateLimited);
+        assert_eq!(sessions[1].status, SessionStatus::Waiting);
     }
 
     #[test]

--- a/src/collector/rate_limit.rs
+++ b/src/collector/rate_limit.rs
@@ -1,5 +1,6 @@
 use crate::model::RateLimitInfo;
 use serde::Deserialize;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 /// File written by the StatusLine hook: ~/.claude/abtop-rate-limits.json
@@ -49,8 +50,9 @@ pub fn read_rate_limits(extra_dirs: &[PathBuf]) -> Vec<RateLimitInfo> {
         if !dir.is_dir() || !seen.insert(dir.clone()) {
             continue;
         }
+        let source = claude_source_for_dir(&dir);
         let path = dir.join(CLAUDE_RATE_FILE);
-        if let Some(info) = read_rate_file(&path, "claude") {
+        if let Some(info) = read_rate_file(&path, &source) {
             results.push(info);
         }
     }
@@ -109,7 +111,7 @@ fn read_rate_file(path: &Path, default_source: &str) -> Option<RateLimitInfo> {
         return None;
     }
 
-    let source = if file.source.is_empty() {
+    let source = if file.source.is_empty() || file.source.eq_ignore_ascii_case("claude") {
         default_source.to_string()
     } else {
         file.source
@@ -123,4 +125,80 @@ fn read_rate_file(path: &Path, default_source: &str) -> Option<RateLimitInfo> {
         seven_day_resets_at: file.seven_day.as_ref().map(|w| w.resets_at),
         updated_at: file.updated_at,
     })
+}
+
+fn claude_source_for_dir(dir: &Path) -> String {
+    let name = dir.file_name().and_then(OsStr::to_str).unwrap_or("claude");
+    let label = name.trim_start_matches('.');
+
+    if label == "claude" {
+        return "claude".to_string();
+    }
+
+    if let Some(profile) = label.strip_prefix("claude-") {
+        if !profile.is_empty() {
+            return format!("claude-{profile}");
+        }
+    }
+
+    format!("claude-{label}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_rate_file(dir: &Path, source: &str, used: f64) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join(CLAUDE_RATE_FILE),
+            format!(
+                r#"{{"source":"{}","five_hour":{{"used_percentage":{},"resets_at":123}},"updated_at":456}}"#,
+                source, used
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn labels_profiled_claude_config_dirs() {
+        assert_eq!(claude_source_for_dir(Path::new("/home/me/.claude")), "claude");
+        assert_eq!(
+            claude_source_for_dir(Path::new("/home/me/.claude-work")),
+            "claude-work"
+        );
+        assert_eq!(
+            claude_source_for_dir(Path::new("/home/me/.claude-personal")),
+            "claude-personal"
+        );
+    }
+
+    #[test]
+    fn read_rate_limits_keeps_profiled_claude_accounts_separate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().join(".claude-work");
+        let personal = tmp.path().join(".claude-personal");
+
+        // abtop --setup writes "source":"claude" in each config dir. The
+        // reader should label the file by config directory so multiple Claude
+        // Code accounts do not collapse into one quota source.
+        write_rate_file(&work, "claude", 10.0);
+        write_rate_file(&personal, "claude", 20.0);
+
+        let rates = read_rate_limits(&[work, personal]);
+        let sources: Vec<_> = rates.iter().map(|r| r.source.as_str()).collect();
+
+        assert!(sources.contains(&"claude-work"));
+        assert!(sources.contains(&"claude-personal"));
+    }
+
+    #[test]
+    fn read_rate_file_preserves_explicit_custom_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_rate_file(tmp.path(), "team-claude", 10.0);
+
+        let rate = read_rate_file(&tmp.path().join(CLAUDE_RATE_FILE), "claude-work").unwrap();
+
+        assert_eq!(rate.source, "team-claude");
+    }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -20,15 +20,34 @@ rl = data.get('rate_limits')
 if not rl:
     sys.exit(0)
 out = {'source': 'claude', 'updated_at': int(time.time())}
-fh = rl.get('five_hour')
+fh = rl.get('five_hour') or rl.get('session')
 if fh:
     out['five_hour'] = {'used_percentage': fh.get('used_percentage', 0), 'resets_at': fh.get('resets_at', 0)}
-sd = rl.get('seven_day')
+sd = rl.get('seven_day') or rl.get('weekly')
 if sd:
     out['seven_day'] = {'used_percentage': sd.get('used_percentage', 0), 'resets_at': sd.get('resets_at', 0)}
-config_dir = os.environ.get('CLAUDE_CONFIG_DIR', os.path.join(os.path.expanduser('~'), '.claude'))
-with open(os.path.join(config_dir, 'abtop-rate-limits.json'), 'w') as f:
+if 'five_hour' not in out and 'seven_day' not in out:
+    sys.exit(0)
+config_dir = None
+transcript_path = data.get('transcript_path')
+if transcript_path:
+    p = os.path.abspath(transcript_path)
+    parts = p.split(os.sep)
+    if 'projects' in parts:
+        idx = parts.index('projects')
+        inferred = os.sep.join(parts[:idx])
+        if inferred:
+            config_dir = inferred
+if not config_dir:
+    config_dir = os.environ.get('CLAUDE_CONFIG_DIR')
+if not config_dir:
+    config_dir = os.path.join(os.path.expanduser('~'), '.claude')
+path = os.path.join(config_dir, 'abtop-rate-limits.json')
+tmp = path + '.tmp'
+os.makedirs(config_dir, exist_ok=True)
+with open(tmp, 'w') as f:
     json.dump(out, f)
+os.replace(tmp, path)
 " 2>/dev/null
 "#;
 

--- a/src/ui/quota.rs
+++ b/src/ui/quota.rs
@@ -12,9 +12,6 @@ use super::{btop_block, fmt_tokens, grad_at, make_gradient, remaining_bar, style
 /// Data considered "stale" when its updated_at is older than this many seconds.
 const STALE_SECS: u64 = 600;
 
-/// Fixed source order so columns stay stable across runs.
-const SOURCES: &[&str] = &["claude", "codex"];
-
 pub(crate) fn draw_quota_panel(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
     let cpu_grad = make_gradient(theme.cpu_grad.start, theme.cpu_grad.mid, theme.cpu_grad.end);
 
@@ -34,14 +31,16 @@ pub(crate) fn draw_quota_panel(f: &mut Frame, app: &App, area: Rect, theme: &The
     let ticks_per_min = 30usize;
     let tokens_per_min: f64 = rates.iter().rev().take(ticks_per_min).sum();
 
-    // Split into side-by-side columns: one per known source (CLAUDE | CODEX).
-    // Columns are always rendered so the panel layout stays stable even when a
-    // source has no data yet.
-    let num_sources = SOURCES.len() as u16;
+    // Split into side-by-side columns: one per known source. Multiple Claude
+    // Code config dirs are rendered as distinct sources (for example
+    // claude-work and claude-personal) so account quotas do not overwrite each
+    // other.
+    let sources = quota_sources(&app.rate_limits);
+    let num_sources = sources.len() as u16;
     let col_w = inner.width / num_sources;
     let content_h = inner.height.saturating_sub(1); // reserve last row for totals
 
-    for (i, source) in SOURCES.iter().enumerate() {
+    for (i, source) in sources.iter().enumerate() {
         let col_x = inner.x + (i as u16) * col_w;
         let this_w = if i as u16 == num_sources - 1 {
             inner.width - (i as u16) * col_w
@@ -67,6 +66,45 @@ pub(crate) fn draw_quota_panel(f: &mut Frame, app: &App, area: Rect, theme: &The
     ])]), bottom_area);
 }
 
+fn quota_sources(rate_limits: &[RateLimitInfo]) -> Vec<String> {
+    let mut sources: Vec<String> = rate_limits
+        .iter()
+        .map(|r| r.source.trim())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect();
+
+    if !sources.iter().any(|s| is_claude_source(s)) {
+        sources.push("claude".to_string());
+    }
+    if !sources.iter().any(|s| s.eq_ignore_ascii_case("codex")) {
+        sources.push("codex".to_string());
+    }
+
+    sources.sort_by(|a, b| {
+        source_sort_key(a)
+            .cmp(&source_sort_key(b))
+            .then_with(|| a.to_ascii_lowercase().cmp(&b.to_ascii_lowercase()))
+    });
+    sources.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+    sources
+}
+
+fn source_sort_key(source: &str) -> u8 {
+    if is_claude_source(source) {
+        0
+    } else if source.eq_ignore_ascii_case("codex") {
+        1
+    } else {
+        2
+    }
+}
+
+fn is_claude_source(source: &str) -> bool {
+    let source = source.to_ascii_lowercase();
+    source == "claude" || source.starts_with("claude-")
+}
+
 fn draw_source_column(
     f: &mut Frame,
     area: Rect,
@@ -79,7 +117,7 @@ fn draw_source_column(
     let bar_w = col_w_usize.saturating_sub(10).clamp(2, 8);
 
     let Some(rl) = rl else {
-        let hint = if source.eq_ignore_ascii_case("claude") {
+        let hint = if is_claude_source(source) {
             "  abtop --setup"
         } else {
             "  run codex once"
@@ -175,5 +213,30 @@ pub(crate) fn format_reset_time(reset_ts: u64) -> String {
         format!("{}h {}m", diff / 3600, (diff % 3600) / 60)
     } else {
         format!("{}d {}h", diff / 86400, (diff % 86400) / 3600)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rate_limit(source: &str) -> RateLimitInfo {
+        RateLimitInfo { source: source.to_string(), ..Default::default() }
+    }
+
+    #[test]
+    fn quota_sources_expands_profiled_claude_accounts() {
+        let sources = quota_sources(&[
+            rate_limit("claude-personal"),
+            rate_limit("codex"),
+            rate_limit("claude-work"),
+        ]);
+
+        assert_eq!(sources, vec!["claude-personal", "claude-work", "codex"]);
+    }
+
+    #[test]
+    fn quota_sources_keeps_default_empty_state() {
+        assert_eq!(quota_sources(&[]), vec!["claude", "codex"]);
     }
 }


### PR DESCRIPTION
## Summary

Support showing separate Claude Code quota sources when users run multiple Claude profiles via `CLAUDE_CONFIG_DIR`.

abtop already discovers sessions from more than one Claude config root, but quota rendering still assumed one Claude source. With profiles such as `~/.claude-work` and `~/.claude-personal`, each config dir can have its own `abtop-rate-limits.json`; treating all of them as plain `claude` makes the quota panel collapse profile-specific data into a single column.

## Implementation

- Derive a stable Claude quota label from the config directory when the rate-limit file uses the default `source: "claude"`.
  - `~/.claude` stays `claude`.
  - `~/.claude-work` renders as `claude-work`.
- Render quota columns from the available rate-limit sources instead of hard-coding `CLAUDE | CODEX`.
- Treat profiled Claude quota labels as Claude-family sources for rate-limit status promotion.
- Update the statusline setup scripts to:
  - prefer `transcript_path` to infer the active Claude config dir, then fall back to `CLAUDE_CONFIG_DIR`, then `~/.claude`,
  - accept both `five_hour` / `seven_day` and `session` / `weekly` payload shapes,
  - write the rate-limit file atomically.

## Test plan

- [x] `cargo test` (96/96 pass)
- [x] `cargo clippy -- -D warnings`
- [x] `git diff --check`
- [x] Installed locally with `cargo install --path . --force` and verified separate Claude profile rate-limit files are produced/read
