### PR TITLE
feat(ui): add toggle for projects panel (#87)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -66,6 +66,7 @@ pub struct App {
     pub show_context: bool,
     pub show_quota: bool,
     pub show_tokens: bool,
+    pub show_projects: bool,
     pub show_ports: bool,
     pub show_sessions: bool,
     pub config_open: bool,
@@ -113,6 +114,7 @@ impl App {
             show_context: true,
             show_quota: true,
             show_tokens: true,
+            show_projects: true,
             show_ports: true,
             show_sessions: true,
             config_open: false,
@@ -147,8 +149,9 @@ impl App {
             1 => self.show_context = !self.show_context,
             2 => self.show_quota = !self.show_quota,
             3 => self.show_tokens = !self.show_tokens,
-            4 => self.show_ports = !self.show_ports,
-            5 => self.show_sessions = !self.show_sessions,
+            4 => self.show_projects = !self.show_projects,
+            5 => self.show_ports = !self.show_ports,
+            6 => self.show_sessions = !self.show_sessions,
             _ => {}
         }
     }
@@ -165,7 +168,7 @@ impl App {
     }
 
     pub fn config_item_count(&self) -> usize {
-        6 // theme + 5 panel toggles
+        7 // theme + 6 panel toggles
     }
 
     pub fn config_select_next(&mut self) {
@@ -184,8 +187,9 @@ impl App {
             1 => self.show_context = !self.show_context,
             2 => self.show_quota = !self.show_quota,
             3 => self.show_tokens = !self.show_tokens,
-            4 => self.show_ports = !self.show_ports,
-            5 => self.show_sessions = !self.show_sessions,
+            4 => self.show_projects = !self.show_projects,
+            5 => self.show_ports = !self.show_ports,
+            6 => self.show_sessions = !self.show_sessions,
             _ => {}
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
                             KeyCode::Char('T') => app.tree_view = !app.tree_view,
                             KeyCode::Char('l') => app.toggle_timeline(),
                             KeyCode::Char('f') => app.toggle_file_audit(),
-                            KeyCode::Char(c @ '1'..='5') => app.toggle_panel(c as u8 - b'0'),
+                            KeyCode::Char(c @ '1'..='6') => app.toggle_panel(c as u8 - b'0'),
                             KeyCode::Char('t') => app.cycle_theme(),
                             _ => {}
                         }
@@ -173,7 +173,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
                             KeyCode::Char('t') => app.cycle_theme(),
                             KeyCode::Char('T') => app.tree_view = !app.tree_view,
                             KeyCode::Char('l') | KeyCode::Char('L') => app.toggle_timeline(),
-                            KeyCode::Char(c @ '1'..='5') => app.toggle_panel(c as u8 - b'0'),
+                            KeyCode::Char(c @ '1'..='6') => app.toggle_panel(c as u8 - b'0'),
                             KeyCode::Char('c') => app.toggle_config(),
                             KeyCode::Char('v') => app.toggle_view_menu(),
                             KeyCode::Char('?') => app.toggle_help(),

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -10,7 +10,7 @@ pub(crate) fn draw_config_overlay(f: &mut Frame, app: &App, theme: &Theme) {
     let area = f.area();
 
     let popup_w = 50u16.min(area.width.saturating_sub(4));
-    let popup_h = 14u16.min(area.height.saturating_sub(4));
+    let popup_h = 15u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(popup_w)) / 2;
     let y = (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
@@ -37,8 +37,9 @@ pub(crate) fn draw_config_overlay(f: &mut Frame, app: &App, theme: &Theme) {
         ("Context panel (1)", toggle_str(app.show_context)),
         ("Quota panel (2)", toggle_str(app.show_quota)),
         ("Tokens panel (3)", toggle_str(app.show_tokens)),
-        ("Ports panel (4)", toggle_str(app.show_ports)),
-        ("Sessions panel (5)", toggle_str(app.show_sessions)),
+        ("Projects panel (4)", toggle_str(app.show_projects)),
+        ("Ports panel (5)", toggle_str(app.show_ports)),
+        ("Sessions panel (6)", toggle_str(app.show_sessions)),
     ];
 
     let mut lines = Vec::new();

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -22,7 +22,7 @@ const ENTRIES: &[(&str, &str)] = &[
     ("  t / T",    "cycle theme / toggle tree"),
     ("  l",        "toggle timeline"),
     ("  f",        "toggle file audit"),
-    ("  1-5",      "toggle panels (context/quota/tokens/ports/sessions)"),
+    ("  1-6",      "toggle panels (context/quota/tokens/projects/ports/sessions)"),
     ("Help", ""),
     ("  ?",        "this help"),
 ];

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -298,8 +298,7 @@ pub fn draw(f: &mut Frame, app: &App) {
     const CONTEXT_MIN: u16 = 5;
     const FIXED: u16 = 2; // header + footer
 
-    // Projects panel is always visible, so the mid row always renders.
-    let any_mid = true;
+    let any_mid = app.show_quota || app.show_tokens || app.show_projects || app.show_ports;
 
     let mid_h_ideal: u16 = 8;
     let sessions_ideal: u16 = if app.show_sessions {
@@ -366,7 +365,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         let mut mid_constraints: Vec<Constraint> = Vec::new();
         if app.show_quota { mid_constraints.push(Constraint::Length(0)); }
         if app.show_tokens { mid_constraints.push(Constraint::Length(0)); }
-        mid_constraints.push(Constraint::Length(0)); // projects always visible
+        if app.show_projects { mid_constraints.push(Constraint::Length(0)); }
         if app.show_ports { mid_constraints.push(Constraint::Length(0)); }
         let count = mid_constraints.len() as u32;
         let mid_constraints: Vec<Constraint> = (0..count).map(|_| Constraint::Ratio(1, count)).collect();
@@ -379,7 +378,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         let mut mi = 0;
         if app.show_quota { quota::draw_quota_panel(f, app, mid_panels[mi], theme); mi += 1; }
         if app.show_tokens { tokens::draw_tokens_panel(f, app, mid_panels[mi], theme); mi += 1; }
-        projects::draw_projects_panel(f, app, mid_panels[mi], theme); mi += 1;
+        if app.show_projects { projects::draw_projects_panel(f, app, mid_panels[mi], theme); mi += 1; }
         if app.show_ports { ports::draw_ports_panel(f, app, mid_panels[mi], theme); }
         idx += 1;
     }

--- a/src/ui/ports.rs
+++ b/src/ui/ports.rs
@@ -83,6 +83,6 @@ pub(crate) fn draw_ports_panel(f: &mut Frame, app: &App, area: Rect, theme: &The
         )));
     }
 
-    let block = btop_block("ports", "⁴", theme.net_box, theme);
+    let block = btop_block("ports", "⁵", theme.net_box, theme);
     f.render_widget(Paragraph::new(lines).block(block), area);
 }

--- a/src/ui/projects.rs
+++ b/src/ui/projects.rs
@@ -61,6 +61,6 @@ pub(crate) fn draw_projects_panel(f: &mut Frame, app: &App, area: Rect, theme: &
         )));
     }
 
-    let block = btop_block("projects", "", theme.mem_box, theme);
+    let block = btop_block("projects", "⁴", theme.mem_box, theme);
     f.render_widget(Paragraph::new(lines).block(block), area);
 }

--- a/src/ui/sessions.rs
+++ b/src/ui/sessions.rs
@@ -11,7 +11,7 @@ use super::{btop_block, fmt_mem_kb, fmt_tokens, grad_at, make_gradient, truncate
 
 pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
     // Render the outer block
-    let block = btop_block("sessions", "⁵", theme.proc_box, theme);
+    let block = btop_block("sessions", "⁶", theme.proc_box, theme);
     f.render_widget(block, area);
 
     let inner = Rect {

--- a/src/ui/view_menu.rs
+++ b/src/ui/view_menu.rs
@@ -31,8 +31,9 @@ pub(crate) fn items(app: &App) -> Vec<ViewItem> {
         ViewItem { key: '1', label: "context panel",   state: bool_state(app.show_context) },
         ViewItem { key: '2', label: "quota panel",     state: bool_state(app.show_quota) },
         ViewItem { key: '3', label: "tokens panel",    state: bool_state(app.show_tokens) },
-        ViewItem { key: '4', label: "ports panel",     state: bool_state(app.show_ports) },
-        ViewItem { key: '5', label: "sessions panel",  state: bool_state(app.show_sessions) },
+        ViewItem { key: '4', label: "projects panel",  state: bool_state(app.show_projects) },
+        ViewItem { key: '5', label: "ports panel",     state: bool_state(app.show_ports) },
+        ViewItem { key: '6', label: "sessions panel",  state: bool_state(app.show_sessions) },
         ViewItem { key: 't', label: "cycle theme",     state: Action },
     ]
 }


### PR DESCRIPTION
## Summary

Closes #87. Adds a toggle for the projects panel, assigned to key \`4\`. Ports moves to \`5\`, sessions to \`6\` so the panel-number badges in each block title (¹²³⁴⁵⁶) stay contiguous and match the hotkeys.

The projects panel was the only mid-row panel without a toggle. Users working outside git repos (or hitting the \`✓clean\` glyph rendering issue with fonts like Sarasa Mono K) had no way to hide it.

## Changes

- \`src/app.rs\`: add \`show_projects\` (default \`true\`), shift \`toggle_panel\` and \`config_toggle_selected\` matches, bump \`config_item_count\` 6 → 7.
- \`src/main.rs\`: hotkey range \`'1'..='5'\` → \`'1'..='6'\` (both view-overlay and main key paths).
- \`src/ui/view_menu.rs\`, \`src/ui/config.rs\`, \`src/ui/help.rs\`: surface the new toggle, shift labels.
- \`src/ui/projects.rs\`, \`src/ui/ports.rs\`, \`src/ui/sessions.rs\`: update the panel-number badges (\`projects\` gets \`⁴\`, \`ports\` \`⁵\`, \`sessions\` \`⁶\`).
- \`src/ui/mod.rs\`: gate the projects panel on \`show_projects\`, and let the mid row collapse entirely when all four mid panels are off.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo test\` (90 passed)
- [x] \`cargo clippy --all-targets\` (no new warnings; pre-existing \`items_after_test_module\` in \`src/ui/sessions.rs:755\` is unchanged)
- [x] Verified hotkeys \`1\`–\`6\` toggle the matching panels and that toggling all four mid panels off collapses the row.