### PR TITLE
feat(config): persist panel visibility across restarts

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -90,7 +90,11 @@ pub struct App {
 }
 
 impl App {
-    pub fn new_with_hidden(theme: Theme, hidden_agents: &[String]) -> Self {
+    pub fn new_with_config(
+        theme: Theme,
+        hidden_agents: &[String],
+        panels: crate::config::PanelVisibility,
+    ) -> Self {
         let (tx, rx) = mpsc::channel();
         let summaries = load_summary_cache();
         Self {
@@ -111,12 +115,12 @@ impl App {
             status_msg: None,
             kill_confirm: None,
             theme,
-            show_context: true,
-            show_quota: true,
-            show_tokens: true,
-            show_projects: true,
-            show_ports: true,
-            show_sessions: true,
+            show_context: panels.context,
+            show_quota: panels.quota,
+            show_tokens: panels.tokens,
+            show_projects: panels.projects,
+            show_ports: panels.ports,
+            show_sessions: panels.sessions,
             config_open: false,
             config_selected: 0,
             tree_view: false,
@@ -152,7 +156,22 @@ impl App {
             4 => self.show_projects = !self.show_projects,
             5 => self.show_ports = !self.show_ports,
             6 => self.show_sessions = !self.show_sessions,
-            _ => {}
+            _ => return,
+        }
+        self.persist_panel_visibility();
+    }
+
+    fn persist_panel_visibility(&mut self) {
+        let panels = crate::config::PanelVisibility {
+            context: self.show_context,
+            quota: self.show_quota,
+            tokens: self.show_tokens,
+            projects: self.show_projects,
+            ports: self.show_ports,
+            sessions: self.show_sessions,
+        };
+        if let Err(e) = crate::config::save_panel_visibility(&panels) {
+            self.set_status(format!("panels save failed: {}", e));
         }
     }
 
@@ -183,15 +202,19 @@ impl App {
 
     pub fn config_toggle_selected(&mut self) {
         match self.config_selected {
-            0 => self.cycle_theme(),
+            0 => {
+                self.cycle_theme();
+                return;
+            }
             1 => self.show_context = !self.show_context,
             2 => self.show_quota = !self.show_quota,
             3 => self.show_tokens = !self.show_tokens,
             4 => self.show_projects = !self.show_projects,
             5 => self.show_ports = !self.show_ports,
             6 => self.show_sessions = !self.show_sessions,
-            _ => {}
+            _ => return,
         }
+        self.persist_panel_visibility();
     }
 
     pub fn toggle_timeline(&mut self) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,34 @@
 use std::path::PathBuf;
 
+#[derive(Clone, Copy)]
+pub struct PanelVisibility {
+    pub context: bool,
+    pub quota: bool,
+    pub tokens: bool,
+    pub projects: bool,
+    pub ports: bool,
+    pub sessions: bool,
+}
+
+impl Default for PanelVisibility {
+    fn default() -> Self {
+        Self {
+            context: true,
+            quota: true,
+            tokens: true,
+            projects: true,
+            ports: true,
+            sessions: true,
+        }
+    }
+}
+
 pub struct AppConfig {
     pub theme: String,
     /// Agent CLI names to exclude from the TUI (e.g. ["codex"] to hide Codex).
     /// Matched case-insensitively against each collector's agent_cli identifier.
     pub hidden_agents: Vec<String>,
+    pub panels: PanelVisibility,
 }
 
 impl Default for AppConfig {
@@ -12,6 +36,7 @@ impl Default for AppConfig {
         Self {
             theme: "btop".to_string(),
             hidden_agents: Vec::new(),
+            panels: PanelVisibility::default(),
         }
     }
 }
@@ -51,12 +76,27 @@ pub fn load_config() -> AppConfig {
                 continue;
             }
             let val = val.trim_matches('"').trim_matches('\'');
-            if key == "theme" {
-                config.theme = val.to_string();
+            match key {
+                "theme" => config.theme = val.to_string(),
+                "show_context"  => config.panels.context  = parse_bool(val).unwrap_or(true),
+                "show_quota"    => config.panels.quota    = parse_bool(val).unwrap_or(true),
+                "show_tokens"   => config.panels.tokens   = parse_bool(val).unwrap_or(true),
+                "show_projects" => config.panels.projects = parse_bool(val).unwrap_or(true),
+                "show_ports"    => config.panels.ports    = parse_bool(val).unwrap_or(true),
+                "show_sessions" => config.panels.sessions = parse_bool(val).unwrap_or(true),
+                _ => {}
             }
         }
     }
     config
+}
+
+fn parse_bool(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
 }
 
 /// Parse a simple one-line TOML string array like `["a", "b"]`.
@@ -74,42 +114,65 @@ fn parse_string_array(raw: &str) -> Vec<String> {
 }
 
 pub fn save_theme(name: &str) -> Result<(), String> {
+    write_with_updates(&[("theme", format!("\"{}\"", name))])
+}
+
+pub fn save_panel_visibility(panels: &PanelVisibility) -> Result<(), String> {
+    write_with_updates(&[
+        ("show_context",  panels.context.to_string()),
+        ("show_quota",    panels.quota.to_string()),
+        ("show_tokens",   panels.tokens.to_string()),
+        ("show_projects", panels.projects.to_string()),
+        ("show_ports",    panels.ports.to_string()),
+        ("show_sessions", panels.sessions.to_string()),
+    ])
+}
+
+/// Read the config, replace or append each (key, value) pair, write it back.
+/// Lines that don't match any key are preserved verbatim so unknown keys and
+/// comments survive saves driven by unrelated parts of the UI.
+fn write_with_updates(updates: &[(&str, String)]) -> Result<(), String> {
     let path = config_path().ok_or("no config directory")?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-
-    // Read existing config, update theme line (NotFound = fresh file, other errors = fail)
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => return Err(e.to_string()),
     };
-    let new_content = rewrite_theme_line(&content, name);
+    let new_content = rewrite_kv_lines(&content, updates);
     std::fs::write(&path, new_content).map_err(|e| e.to_string())
 }
 
-/// Rewrite (or append) the `theme = "..."` line in a config file body.
-/// Every other line is preserved verbatim, so keys like `hidden_agents`
-/// set by the user or by a future save_* helper survive theme switches.
-fn rewrite_theme_line(content: &str, name: &str) -> String {
-    let mut lines: Vec<String> = Vec::new();
-    let mut found = false;
+/// Rewrite (or append) the listed `key = value` lines in a config body.
+/// Every other line is preserved verbatim so keys set by the user or by a
+/// different save_* helper survive.
+fn rewrite_kv_lines(content: &str, updates: &[(&str, String)]) -> String {
+    let mut found = vec![false; updates.len()];
+    let mut out: Vec<String> = Vec::new();
     for line in content.lines() {
-        let is_theme_key = line.split_once('=')
-            .map(|(k, _)| k.trim() == "theme")
-            .unwrap_or(false);
-        if is_theme_key {
-            lines.push(format!("theme = \"{}\"", name));
-            found = true;
-        } else {
-            lines.push(line.to_string());
+        let line_key = line
+            .split_once('=')
+            .map(|(k, _)| k.trim().to_string());
+        let mut replaced = false;
+        if let Some(key) = line_key {
+            if let Some(idx) = updates.iter().position(|(k, _)| *k == key) {
+                out.push(format!("{} = {}", updates[idx].0, updates[idx].1));
+                found[idx] = true;
+                replaced = true;
+            }
+        }
+        if !replaced {
+            out.push(line.to_string());
         }
     }
-    if !found {
-        lines.push(format!("theme = \"{}\"", name));
+    for (idx, (k, v)) in updates.iter().enumerate() {
+        if !found[idx] {
+            out.push(format!("{} = {}", k, v));
+        }
     }
-    lines.join("\n") + "\n"
+    out.join("\n") + "\n"
 }
 
 #[cfg(test)]
@@ -140,21 +203,25 @@ mod tests {
         assert!(parse_string_array(r#"["a",,]"#).iter().all(|s| !s.is_empty()) );
     }
 
+    fn theme_update(name: &str) -> Vec<(&'static str, String)> {
+        vec![("theme", format!("\"{}\"", name))]
+    }
+
     #[test]
     fn rewrite_theme_preserves_hidden_agents_line() {
         let before = "theme = \"btop\"\nhidden_agents = [\"codex\"]\n";
-        let after = rewrite_theme_line(before, "dracula");
+        let after = rewrite_kv_lines(before, &theme_update("dracula"));
         assert!(after.contains("theme = \"dracula\""));
         assert!(
             after.contains("hidden_agents = [\"codex\"]"),
-            "hidden_agents line dropped by rewrite_theme_line:\n{after}"
+            "hidden_agents line dropped:\n{after}"
         );
     }
 
     #[test]
     fn rewrite_theme_preserves_arbitrary_unknown_keys() {
         let before = "# user comment\nfuture_key = 42\ntheme = \"btop\"\n";
-        let after = rewrite_theme_line(before, "nord");
+        let after = rewrite_kv_lines(before, &theme_update("nord"));
         assert!(after.contains("# user comment"));
         assert!(after.contains("future_key = 42"));
         assert!(after.contains("theme = \"nord\""));
@@ -163,8 +230,29 @@ mod tests {
     #[test]
     fn rewrite_theme_appends_when_missing() {
         let before = "hidden_agents = [\"codex\"]\n";
-        let after = rewrite_theme_line(before, "gruvbox");
+        let after = rewrite_kv_lines(before, &theme_update("gruvbox"));
         assert!(after.contains("hidden_agents = [\"codex\"]"));
         assert!(after.contains("theme = \"gruvbox\""));
+    }
+
+    #[test]
+    fn rewrite_panels_replaces_existing_and_appends_missing() {
+        let before = "theme = \"btop\"\nshow_quota = true\n";
+        let updates: Vec<(&str, String)> = vec![
+            ("show_quota", "false".to_string()),
+            ("show_projects", "false".to_string()),
+        ];
+        let after = rewrite_kv_lines(before, &updates);
+        assert!(after.contains("show_quota = false"));
+        assert!(!after.contains("show_quota = true"));
+        assert!(after.contains("show_projects = false"));
+        assert!(after.contains("theme = \"btop\""));
+    }
+
+    #[test]
+    fn parse_bool_round_trips_visibility_keys() {
+        assert_eq!(parse_bool("true"), Some(true));
+        assert_eq!(parse_bool("False"), Some(false));
+        assert_eq!(parse_bool("nope"), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,9 +75,10 @@ fn main() -> io::Result<()> {
 
     // --once flag: print snapshot and exit
     if std::env::args().any(|a| a == "--once") {
-        let mut app = App::new_with_hidden(
+        let mut app = App::new_with_config(
             initial_theme.unwrap_or_default(),
             &cfg.hidden_agents,
+            cfg.panels,
         );
         if demo_mode {
             demo::populate_demo(&mut app);
@@ -102,7 +103,7 @@ fn main() -> io::Result<()> {
     stdout().execute(EnterAlternateScreen)?;
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
 
-    let app_result = run_app(&mut terminal, demo_mode, initial_theme, exit_on_jump, &cfg.hidden_agents);
+    let app_result = run_app(&mut terminal, demo_mode, initial_theme, exit_on_jump, &cfg.hidden_agents, cfg.panels);
 
     // Always attempt both cleanup steps regardless of app result
     let r1 = disable_raw_mode();
@@ -112,8 +113,8 @@ fn main() -> io::Result<()> {
     app_result.and(r1).and(r2)
 }
 
-fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: bool, initial_theme: Option<theme::Theme>, exit_on_jump: bool, hidden_agents: &[String]) -> io::Result<()> {
-    let mut app = App::new_with_hidden(initial_theme.unwrap_or_default(), hidden_agents);
+fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: bool, initial_theme: Option<theme::Theme>, exit_on_jump: bool, hidden_agents: &[String], panels: config::PanelVisibility) -> io::Result<()> {
+    let mut app = App::new_with_config(initial_theme.unwrap_or_default(), hidden_agents, panels);
     if demo_mode {
         demo::populate_demo(&mut app);
     } else {


### PR DESCRIPTION
## Summary

Stacked on #91. Panel toggles (1–6, or via the \`c\` overlay) now persist to \`~/.config/abtop/config.toml\` so a layout the user picked survives a restart.

## Changes

- \`src/config.rs\`:
  - New \`PanelVisibility\` struct with one bool per panel; \`AppConfig\` carries it. Missing or malformed keys fall back to \`true\` so an empty config still renders the full UI.
  - Parse \`show_context\` / \`show_quota\` / \`show_tokens\` / \`show_projects\` / \`show_ports\` / \`show_sessions\` from \`config.toml\`.
  - Refactor \`rewrite_theme_line\` into a generic \`rewrite_kv_lines(content, &[(key, value)])\` so both \`save_theme\` and the new \`save_panel_visibility\` share one preserve-unknown-lines path. Comments, \`hidden_agents\`, and any future keys survive both kinds of saves.

- \`src/app.rs\`:
  - \`App::new_with_config\` now takes a \`PanelVisibility\` and seeds the six \`show_*\` flags from it.
  - \`toggle_panel\` and \`config_toggle_selected\` call a new \`persist_panel_visibility\` helper after each change. Save failures surface in the existing transient status footer; success is silent (the panel disappearing/appearing is the visible feedback).
  - \`new_with_hidden\` removed (only one call path remained, and bundling visibility into the constructor signature is cleaner than two near-duplicate helpers).

- \`src/main.rs\`: thread \`cfg.panels\` from \`load_config\` into both the \`--once\` and TUI app constructors.

## Notes

- Stacked on #91 — review that one first; this PR's base will auto-update to \`main\` once #91 lands.
- Saves run on every toggle (atomic \`fs::write\` of a small TOML file). No measurable cost on local disk; the existing \`save_theme\` already uses the same write pattern.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo test\` (92 passed, including 2 new ones for \`rewrite_kv_lines\` multi-key behavior and \`parse_bool\`)
- [x] \`cargo clippy --all-targets\` (no new warnings)
- [x] Manually verified: toggle \`4\` (projects) off, quit, restart → projects stays hidden. Toggle back on → restored after restart.