### PR TITLE
process: match Claude Code 2.x autoupdater binary layout

### DIFF
--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -1703,6 +1703,13 @@ fn read_env_var_from_proc(pid: u32, var_name: &str) -> Option<String> {
 /// without elevated privileges, so per-process `CLAUDE_CONFIG_DIR` overrides
 /// can't be detected — abtop's own env (resolved in `refresh_config_dirs`)
 /// is the only signal there.
+///
+/// On macOS, `ps eww`/`KERN_PROCARGS2` are unreliable: the kernel truncates
+/// the env block to ~120 chars for non-root callers, so `CLAUDE_CONFIG_DIR`
+/// is rarely visible. Discovery of profile sessions instead piggybacks on
+/// `libproc` open-FD inspection (see `discover_active_session_paths`), which
+/// reads the actual session-file paths a Claude process has open and infers
+/// the config dir from there.
 #[cfg(not(target_os = "linux"))]
 fn read_env_var_from_proc(_pid: u32, _var_name: &str) -> Option<String> {
     None

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -368,12 +368,12 @@ pub fn last_path_segment(s: &str) -> Option<&str> {
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     let mut tokens = cmd.split_whitespace().take(2);
     tokens.any(|tok| {
-        let base = tok.rsplit('/').next().unwrap_or(tok);
+        let mut iter = tok.rsplit('/');
+        let base = iter.next().unwrap_or(tok);
         if base == name {
             return true;
         }
-        let parts: Vec<&str> = tok.rsplit('/').collect();
-        parts.len() >= 3 && parts[1] == "versions" && parts[2] == name
+        matches!((iter.next(), iter.next()), (Some("versions"), Some(parent)) if parent == name)
     })
 }
 
@@ -384,15 +384,17 @@ pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     let mut tokens = cmd.split_whitespace().take(2);
     tokens.any(|tok| {
-        let base = tok.rsplit(['/', '\\']).next().unwrap_or(tok);
+        let mut iter = tok.rsplit(['/', '\\']);
+        let base = iter.next().unwrap_or(tok);
         let base = base.strip_suffix(".exe").unwrap_or(base);
         if base.eq_ignore_ascii_case(name) {
             return true;
         }
-        let parts: Vec<&str> = tok.rsplit(['/', '\\']).collect();
-        parts.len() >= 3
-            && parts[1].eq_ignore_ascii_case("versions")
-            && parts[2].eq_ignore_ascii_case(name)
+        matches!(
+            (iter.next(), iter.next()),
+            (Some(versions), Some(parent))
+                if versions.eq_ignore_ascii_case("versions") && parent.eq_ignore_ascii_case(name)
+        )
     })
 }
 

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -359,12 +359,21 @@ pub fn last_path_segment(s: &str) -> Option<&str> {
 /// Check if a command string has a given binary name in executable position.
 /// Checks the first two argv tokens only (covers direct invocation and
 /// interpreter-wrapped scripts like `node /path/to/codex ...`).
+///
+/// Also matches the autoupdater layout used by Claude Code 2.x where the
+/// running binary is named after its version (e.g.
+/// `~/.local/share/claude/versions/2.1.121`) — basename equality alone would
+/// miss this, so we also accept any path of the form `<...>/<name>/versions/<filename>`.
 #[cfg(not(windows))]
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     let mut tokens = cmd.split_whitespace().take(2);
     tokens.any(|tok| {
         let base = tok.rsplit('/').next().unwrap_or(tok);
-        base == name
+        if base == name {
+            return true;
+        }
+        let parts: Vec<&str> = tok.rsplit('/').collect();
+        parts.len() >= 3 && parts[1] == "versions" && parts[2] == name
     })
 }
 
@@ -377,7 +386,13 @@ pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     tokens.any(|tok| {
         let base = tok.rsplit(['/', '\\']).next().unwrap_or(tok);
         let base = base.strip_suffix(".exe").unwrap_or(base);
-        base.eq_ignore_ascii_case(name)
+        if base.eq_ignore_ascii_case(name) {
+            return true;
+        }
+        let parts: Vec<&str> = tok.rsplit(['/', '\\']).collect();
+        parts.len() >= 3
+            && parts[1].eq_ignore_ascii_case("versions")
+            && parts[2].eq_ignore_ascii_case(name)
     })
 }
 
@@ -412,4 +427,38 @@ pub fn collect_git_stats(cwd: &str) -> (u32, u32) {
     }
 
     (added, modified)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmd_has_binary_basename_match() {
+        assert!(cmd_has_binary("/usr/local/bin/claude --foo", "claude"));
+        assert!(cmd_has_binary("claude", "claude"));
+        assert!(!cmd_has_binary("/usr/local/bin/claude-launch", "claude"));
+    }
+
+    #[test]
+    fn cmd_has_binary_autoupdater_layout() {
+        // Claude Code 2.x: actual binary is named after its version, but the
+        // path has `<name>/versions/<file>` structure we can match on.
+        assert!(cmd_has_binary(
+            "/Users/a/.local/share/claude/versions/2.1.121 --allow-dangerously-skip-permissions",
+            "claude",
+        ));
+        assert!(cmd_has_binary(
+            "/opt/codex/versions/0.42.0 --foo",
+            "codex",
+        ));
+    }
+
+    #[test]
+    fn cmd_has_binary_does_not_overmatch() {
+        // A sibling dir under `claude/` but not under `versions/` shouldn't match.
+        assert!(!cmd_has_binary("/Users/a/.local/share/claude/foo", "claude"));
+        // A `versions/` dir not under `<name>/` shouldn't match either.
+        assert!(!cmd_has_binary("/some/versions/2.1.121", "claude"));
+    }
 }


### PR DESCRIPTION
Fixes #93.

`cmd_has_binary("claude")` only checked the binary basename. Claude Code 2.x runs the version-named binary directly (e.g. `~/.local/share/claude/versions/2.1.121`), so the basename is the version string — detection fails and live Claude sessions never appear in the session list on macOS.

Extend the matcher to also accept the autoupdater layout `<...>/<name>/versions/<file>`. Conservative pattern: a generic substring match or a dir-named-`claude` check would over-match unrelated paths. Same change applied to the Windows variant for consistency.

A second pass at adding macOS env discovery (`KERN_PROCARGS2` / `ps eww`) was tried and abandoned — the kernel truncates the env block to ~120 chars for non-root callers, so the read is unreliable. The existing libproc open-FD inspection in `discover_active_session_paths` already partially compensates. The non-Linux `read_env_var_from_proc` stub is now annotated with a comment explaining this for the next person who looks.

## Verification

```
$ cargo test --release
test result: 96 passed; 0 failed
```

(3 new tests in `src/collector/process.rs::tests` covering basename match, autoupdater layout, and a non-overmatch guard.)

On a Mac with 5 Claude Code 2.1.121 sessions running:

| | sessions visible |
|---|---|
| before | 3 (codex only) |
| after  | 8 (5 Claude + 3 codex) |