### PR TITLE
Detect codex mcp-server processes in a dedicated MCP panel

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::collector::{MultiCollector, read_rate_limits};
+use crate::collector::{McpServer, MultiCollector, read_rate_limits};
 use crate::host_info::{AgentAggregate, HostMetrics, HostSampler};
 use crate::model::{AgentSession, OrphanPort, RateLimitInfo, SessionStatus};
 use crate::theme::Theme;
@@ -69,6 +69,14 @@ pub struct App {
     pub show_projects: bool,
     pub show_ports: bool,
     pub show_sessions: bool,
+    pub show_mcp: bool,
+    /// MCP servers detected on the most recent tick (sourced from
+    /// MultiCollector). Populated regardless of `show_mcp` so panel
+    /// toggling doesn't cost a discovery roundtrip.
+    pub mcp_servers: Vec<McpServer>,
+    /// When true (default), mcp-server-owned rollouts are hidden from
+    /// the sessions panel. Toggle with Shift+M.
+    pub mcp_suppress_sessions: bool,
     pub config_open: bool,
     pub config_selected: usize,
     pub tree_view: bool,
@@ -97,6 +105,8 @@ impl App {
     ) -> Self {
         let (tx, rx) = mpsc::channel();
         let summaries = load_summary_cache();
+        let mut collector = MultiCollector::with_hidden(hidden_agents);
+        collector.set_mcp_suppress(true);
         Self {
             sessions: Vec::new(),
             selected: 0,
@@ -105,7 +115,7 @@ impl App {
             rate_limits: Vec::new(),
             prev_tokens: HashMap::new(),
             rate_limit_counter: 5,
-            collector: MultiCollector::with_hidden(hidden_agents),
+            collector,
             summaries,
             pending_summaries: HashSet::new(),
             summary_retries: HashMap::new(),
@@ -121,6 +131,9 @@ impl App {
             show_projects: panels.projects,
             show_ports: panels.ports,
             show_sessions: panels.sessions,
+            show_mcp: panels.mcp,
+            mcp_servers: Vec::new(),
+            mcp_suppress_sessions: true,
             config_open: false,
             config_selected: 0,
             tree_view: false,
@@ -156,9 +169,20 @@ impl App {
             4 => self.show_projects = !self.show_projects,
             5 => self.show_ports = !self.show_ports,
             6 => self.show_sessions = !self.show_sessions,
+            7 => self.show_mcp = !self.show_mcp,
             _ => return,
         }
         self.persist_panel_visibility();
+    }
+
+    /// Toggle whether mcp-server-owned rollouts are hidden from the
+    /// sessions panel. Default is on; turning it off restores upstream
+    /// behavior so the user can see exactly what mcp-server fd holding
+    /// produces (mostly stale "Done" rows).
+    pub fn toggle_mcp_session_suppression(&mut self) {
+        self.mcp_suppress_sessions = !self.mcp_suppress_sessions;
+        let label = if self.mcp_suppress_sessions { "on" } else { "off" };
+        self.set_status(format!("mcp session suppression: {}", label));
     }
 
     fn persist_panel_visibility(&mut self) {
@@ -169,6 +193,7 @@ impl App {
             projects: self.show_projects,
             ports: self.show_ports,
             sessions: self.show_sessions,
+            mcp: self.show_mcp,
         };
         if let Err(e) = crate::config::save_panel_visibility(&panels) {
             self.set_status(format!("panels save failed: {}", e));
@@ -187,7 +212,7 @@ impl App {
     }
 
     pub fn config_item_count(&self) -> usize {
-        7 // theme + 6 panel toggles
+        8 // theme + 7 panel toggles
     }
 
     pub fn config_select_next(&mut self) {
@@ -212,6 +237,7 @@ impl App {
             4 => self.show_projects = !self.show_projects,
             5 => self.show_ports = !self.show_ports,
             6 => self.show_sessions = !self.show_sessions,
+            7 => self.show_mcp = !self.show_mcp,
             _ => return,
         }
         self.persist_panel_visibility();
@@ -241,8 +267,10 @@ impl App {
 
 
     pub fn tick(&mut self) {
+        self.collector.set_mcp_suppress(self.mcp_suppress_sessions);
         self.sessions = self.collector.collect();
         self.orphan_ports = self.collector.orphan_ports.clone();
+        self.mcp_servers = self.collector.mcp_servers.clone();
         self.host_metrics = self.host_sampler.sample();
         self.agent_aggregate = AgentAggregate::from_sessions(&self.sessions);
         if self.selected >= self.sessions.len() && !self.sessions.is_empty() {

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -44,8 +44,13 @@ impl CodexCollector {
         // Reset live rate limit each pass — only keep it if a current session provides one
         self.last_rate_limit = None;
 
-        // Step 1: Find running codex processes from shared ps data (no extra ps call)
-        let codex_pids = Self::find_codex_pids_from_shared(&shared.process_info);
+        // Step 1: Find running codex processes from shared ps data (no extra ps call).
+        // When MCP suppression is on, exclude `codex mcp-server` PIDs — those
+        // are surfaced through the MCP servers panel instead. See issue #95.
+        let codex_pids = Self::find_codex_pids_from_shared(
+            &shared.process_info,
+            &shared.mcp_server_pids,
+        );
         let just_pids: Vec<u32> = codex_pids.iter().map(|(p, _)| *p).collect();
         let pid_to_jsonl = Self::map_pid_to_jsonl(&just_pids);
         let pid_is_exec: HashMap<u32, bool> = codex_pids.into_iter().collect();
@@ -93,6 +98,14 @@ impl CodexCollector {
                         continue;
                     }
                     if seen_jsonl.contains(&path) {
+                        continue;
+                    }
+                    // Skip rollouts still held open by an mcp-server PID:
+                    // the thread isn't actually finished, the mcp-server is
+                    // just holding the fd for resume. Without this skip, the
+                    // sessions panel grows a PID=0 "Done" row for every
+                    // historical thread on every active mcp-server.
+                    if shared.mcp_owned_rollouts.contains(&path) {
                         continue;
                     }
                     // Only show recently finished sessions (< 5 min old)
@@ -281,9 +294,17 @@ impl CodexCollector {
 
     /// Find PIDs of running codex processes from shared process data (no extra ps call).
     /// Returns (pid, is_exec) tuples — `is_exec` is true for one-shot `codex exec` runs.
-    fn find_codex_pids_from_shared(process_info: &HashMap<u32, ProcInfo>) -> Vec<(u32, bool)> {
+    /// PIDs in `mcp_server_pids` are skipped so `codex mcp-server` processes
+    /// are reported via the MCP servers panel instead.
+    fn find_codex_pids_from_shared(
+        process_info: &HashMap<u32, ProcInfo>,
+        mcp_server_pids: &std::collections::HashSet<u32>,
+    ) -> Vec<(u32, bool)> {
         let mut pids = Vec::new();
         for (pid, info) in process_info {
+            if mcp_server_pids.contains(pid) {
+                continue;
+            }
             let cmd = &info.command;
             let is_exec = cmd.contains(" exec");
             let is_codex = process::cmd_has_binary(cmd, "codex");

--- a/src/collector/mcp.rs
+++ b/src/collector/mcp.rs
@@ -1,0 +1,354 @@
+use super::process::{self, ProcInfo};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
+use std::process::Command;
+use std::time::SystemTime;
+
+/// Active-thread mtime threshold: a rollout written within the last
+/// ACTIVE_MTIME_SECS counts as "active". File-descriptor presence alone
+/// would overcount — `codex mcp-server` keeps fds open for hours after
+/// a thread last wrote (so it can resume on demand), so we need a
+/// freshness signal in addition to fd presence.
+pub const ACTIVE_MTIME_SECS: u64 = 30;
+
+/// One open `rollout-*.jsonl` fd held by an mcp-server process.
+#[derive(Clone, Debug)]
+pub struct McpRollout {
+    pub path: PathBuf,
+    pub mtime: Option<SystemTime>,
+    /// Carried for debug / future panel use; not currently rendered.
+    #[allow(dead_code)]
+    pub size_bytes: u64,
+}
+
+impl McpRollout {
+    pub fn is_active(&self, now: SystemTime, threshold_secs: u64) -> bool {
+        match self.mtime {
+            Some(m) => now.duration_since(m).map(|d| d.as_secs() < threshold_secs).unwrap_or(false),
+            None => false,
+        }
+    }
+}
+
+/// One running MCP server process. Currently only `codex mcp-server`;
+/// other MCP server flavors can be added by extending the detection in
+/// `is_codex_mcp_server`.
+#[derive(Clone, Debug)]
+pub struct McpServer {
+    pub pid: u32,
+    /// Parent process PID — kept for debug; not currently rendered.
+    #[allow(dead_code)]
+    pub ppid: u32,
+    /// Resolved CLI of the parent process: "claude", "codex", or "?".
+    pub parent_cli: &'static str,
+    /// Full ps command — kept for debug; not currently rendered.
+    #[allow(dead_code)]
+    pub command: String,
+    /// Value of `-c profile=<name>` if present (e.g. "qwen36-litellm").
+    /// `None` for the default profile.
+    pub profile: Option<String>,
+    /// RSS in KB — kept for debug; not currently rendered.
+    #[allow(dead_code)]
+    pub mem_kb: u64,
+    pub rollouts: Vec<McpRollout>,
+}
+
+impl McpServer {
+    pub fn active_count(&self, now: SystemTime, threshold_secs: u64) -> usize {
+        self.rollouts.iter().filter(|r| r.is_active(now, threshold_secs)).count()
+    }
+
+    pub fn latest_mtime(&self) -> Option<SystemTime> {
+        self.rollouts.iter().filter_map(|r| r.mtime).max()
+    }
+}
+
+/// Result of one detection pass — kept as a struct so callers can mutate
+/// a `SharedProcessData` with a single method.
+pub struct McpDetection {
+    pub servers: Vec<McpServer>,
+    /// PIDs of detected mcp-server processes. CodexCollector excludes
+    /// these so the same rollout isn't double-counted in the sessions
+    /// panel.
+    pub server_pids: HashSet<u32>,
+    /// Rollout file paths currently held open by an mcp-server process.
+    /// CodexCollector's "recently finished" pass skips these to avoid
+    /// the PID=0 "ghost Done" rows.
+    pub owned_rollouts: HashSet<PathBuf>,
+}
+
+impl McpDetection {
+    pub fn empty() -> Self {
+        Self { servers: Vec::new(), server_pids: HashSet::new(), owned_rollouts: HashSet::new() }
+    }
+}
+
+/// Detect codex mcp-server processes from the shared `ps` snapshot,
+/// then map each PID to its full set of open rollout fds.
+pub fn detect(process_info: &HashMap<u32, ProcInfo>) -> McpDetection {
+    let server_candidates: Vec<&ProcInfo> = process_info
+        .values()
+        .filter(|info| is_codex_mcp_server(&info.command))
+        .collect();
+
+    if server_candidates.is_empty() {
+        return McpDetection::empty();
+    }
+
+    let pids: Vec<u32> = server_candidates.iter().map(|p| p.pid).collect();
+    let pid_to_rollouts = map_pid_to_rollouts(&pids);
+
+    let mut servers = Vec::with_capacity(server_candidates.len());
+    let mut owned_rollouts: HashSet<PathBuf> = HashSet::new();
+    let mut server_pids: HashSet<u32> = HashSet::new();
+
+    for info in server_candidates {
+        let parent_cli = resolve_parent_cli(info.ppid, process_info);
+        let profile = parse_profile_flag(&info.command);
+        let mut rollouts: Vec<McpRollout> = pid_to_rollouts
+            .get(&info.pid)
+            .map(|paths| paths.iter().map(rollout_for_path).collect())
+            .unwrap_or_default();
+        rollouts.sort_by_key(|r| std::cmp::Reverse(r.mtime));
+
+        for r in &rollouts {
+            owned_rollouts.insert(r.path.clone());
+        }
+        server_pids.insert(info.pid);
+
+        servers.push(McpServer {
+            pid: info.pid,
+            ppid: info.ppid,
+            parent_cli,
+            command: info.command.clone(),
+            profile,
+            mem_kb: info.rss_kb,
+            rollouts,
+        });
+    }
+
+    servers.sort_by_key(|s| (s.parent_cli, s.pid));
+
+    McpDetection { servers, server_pids, owned_rollouts }
+}
+
+/// True when `cmd` is a `codex mcp-server [...]` invocation.
+fn is_codex_mcp_server(cmd: &str) -> bool {
+    process::cmd_has_binary(cmd, "codex")
+        && cmd.contains("mcp-server")
+        && !cmd.contains("grep")
+        && !cmd.contains("app-server")
+}
+
+/// Pick the parent CLI name from the parent's command line, returning
+/// the static label used by the sessions panel.
+fn resolve_parent_cli(ppid: u32, process_info: &HashMap<u32, ProcInfo>) -> &'static str {
+    let Some(parent) = process_info.get(&ppid) else {
+        return "?";
+    };
+    let cmd = &parent.command;
+    if process::cmd_has_binary(cmd, "claude") {
+        "claude"
+    } else if process::cmd_has_binary(cmd, "codex") {
+        "codex"
+    } else {
+        "?"
+    }
+}
+
+/// Extract `-c profile=<name>` if present. Codex accepts either
+/// `-c profile=NAME` (one arg) or `-c` `profile=NAME` (two args). The
+/// substring match handles both since both produce contiguous bytes
+/// in `ps`-style output.
+fn parse_profile_flag(cmd: &str) -> Option<String> {
+    let needle = "profile=";
+    let pos = cmd.find(needle)?;
+    let tail = &cmd[pos + needle.len()..];
+    let end = tail
+        .find(|c: char| c.is_whitespace())
+        .unwrap_or(tail.len());
+    let value = tail[..end].trim_matches(|c: char| c == '"' || c == '\'');
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn rollout_for_path(path: &PathBuf) -> McpRollout {
+    let (mtime, size_bytes) = match std::fs::metadata(path) {
+        Ok(meta) => (meta.modified().ok(), meta.len()),
+        Err(_) => (None, 0),
+    };
+    McpRollout { path: path.clone(), mtime, size_bytes }
+}
+
+/// Map mcp-server PIDs to all their open `rollout-*.jsonl` paths.
+/// Returns one Vec per PID — preserves the multi-rollout fact rather
+/// than the single-PathBuf overwrite the existing CodexCollector path
+/// uses (that is intentional in CodexCollector — see issue notes —
+/// since fixing it without this MCP panel would flood the sessions
+/// panel with phantom rows).
+pub(crate) fn map_pid_to_rollouts(pids: &[u32]) -> HashMap<u32, Vec<PathBuf>> {
+    let mut map: HashMap<u32, Vec<PathBuf>> = HashMap::new();
+    if pids.is_empty() {
+        return map;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        for &pid in pids {
+            for target in process::scan_proc_fds(pid) {
+                if is_rollout_path(&target) {
+                    map.entry(pid).or_default().push(target);
+                }
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let mut sys = sysinfo::System::new();
+        let pids_sys: Vec<sysinfo::Pid> = pids
+            .iter()
+            .copied()
+            .map(|p| sysinfo::Pid::from(p as usize))
+            .collect();
+        sys.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::Some(&pids_sys),
+            true,
+            sysinfo::ProcessRefreshKind::new().with_memory(),
+        );
+        for &pid_u32 in pids {
+            let pid = sysinfo::Pid::from(pid_u32 as usize);
+            if let Some(proc_) = sys.process(pid) {
+                if let Some(cwd) = proc_.cwd() {
+                    if let Ok(entries) = std::fs::read_dir(cwd) {
+                        for entry in entries.flatten() {
+                            let p = entry.path();
+                            if is_rollout_path(&p) {
+                                map.entry(pid_u32).or_default().push(p);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
+    {
+        let pid_args: Vec<String> = pids.iter().map(|p| format!("-p{}", p)).collect();
+        let mut args = vec!["-F", "pn"];
+        for pa in &pid_args {
+            args.push(pa);
+        }
+        let output = Command::new("lsof").args(&args).output().ok();
+        if let Some(output) = output {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let mut current_pid: Option<u32> = None;
+            for line in stdout.lines() {
+                if let Some(pid_str) = line.strip_prefix('p') {
+                    current_pid = pid_str.parse::<u32>().ok();
+                } else if let Some(name) = line.strip_prefix('n') {
+                    if let Some(pid) = current_pid {
+                        let path = PathBuf::from(name);
+                        if is_rollout_path(&path) {
+                            map.entry(pid).or_default().push(path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    map
+}
+
+fn is_rollout_path(p: &Path) -> bool {
+    p.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with("rollout-") && n.ends_with(".jsonl"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proc(pid: u32, ppid: u32, command: &str) -> ProcInfo {
+        ProcInfo {
+            pid,
+            ppid,
+            rss_kb: 0,
+            cpu_pct: 0.0,
+            command: command.to_string(),
+        }
+    }
+
+    #[test]
+    fn detects_codex_mcp_server_default_profile() {
+        let mut info = HashMap::new();
+        info.insert(100, proc(100, 50, "codex mcp-server"));
+        info.insert(50, proc(50, 1, "/usr/local/bin/claude --foo"));
+        let det = detect(&info);
+        assert_eq!(det.servers.len(), 1);
+        assert_eq!(det.servers[0].pid, 100);
+        assert_eq!(det.servers[0].parent_cli, "claude");
+        assert!(det.servers[0].profile.is_none());
+    }
+
+    #[test]
+    fn parses_profile_flag() {
+        let mut info = HashMap::new();
+        info.insert(101, proc(101, 50, "codex mcp-server -c profile=qwen36-litellm"));
+        info.insert(50, proc(50, 1, "claude"));
+        let det = detect(&info);
+        assert_eq!(det.servers.len(), 1);
+        assert_eq!(det.servers[0].profile.as_deref(), Some("qwen36-litellm"));
+    }
+
+    #[test]
+    fn parent_cli_unknown_when_ppid_missing() {
+        let mut info = HashMap::new();
+        info.insert(102, proc(102, 999, "codex mcp-server"));
+        let det = detect(&info);
+        assert_eq!(det.servers[0].parent_cli, "?");
+    }
+
+    #[test]
+    fn ignores_non_mcp_codex_processes() {
+        let mut info = HashMap::new();
+        info.insert(103, proc(103, 1, "codex"));
+        info.insert(104, proc(104, 1, "codex exec something"));
+        info.insert(105, proc(105, 1, "/path/to/codex --resume xyz"));
+        let det = detect(&info);
+        assert!(det.servers.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_codex_mcp_servers() {
+        let mut info = HashMap::new();
+        // claude has its own `mcp serve` that we don't want to pick up here.
+        info.insert(106, proc(106, 1, "/path/to/claude mcp serve"));
+        let det = detect(&info);
+        assert!(det.servers.is_empty());
+    }
+
+    #[test]
+    fn rollout_active_threshold_excludes_old_mtime() {
+        let now = SystemTime::now();
+        let stale = McpRollout {
+            path: PathBuf::from("/x"),
+            mtime: Some(now - std::time::Duration::from_secs(120)),
+            size_bytes: 0,
+        };
+        let fresh = McpRollout {
+            path: PathBuf::from("/y"),
+            mtime: Some(now - std::time::Duration::from_secs(5)),
+            size_bytes: 0,
+        };
+        assert!(!stale.is_active(now, ACTIVE_MTIME_SECS));
+        assert!(fresh.is_active(now, ACTIVE_MTIME_SECS));
+    }
+}

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,10 +1,12 @@
 pub mod claude;
 pub mod codex;
+pub mod mcp;
 pub mod process;
 pub mod rate_limit;
 
 pub use claude::ClaudeCollector;
 pub use codex::CodexCollector;
+pub use mcp::McpServer;
 pub use rate_limit::read_rate_limits;
 
 /// Redact common secret patterns to avoid displaying credentials in the TUI.
@@ -41,7 +43,8 @@ pub(crate) fn redact_secrets(s: &str) -> String {
 }
 
 use crate::model::{AgentSession, OrphanPort, RateLimitInfo, SessionStatus};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 /// Trait for agent-specific session collectors.
 /// Implement this to add support for a new AI coding agent.
@@ -70,6 +73,20 @@ pub struct SharedProcessData {
     /// True on slow poll ticks (every 5 ticks ≈ 10s). Collectors should
     /// defer expensive discovery (e.g. /proc reads) to slow ticks.
     pub slow_tick: bool,
+    /// PIDs of detected codex mcp-server processes. Populated by
+    /// `MultiCollector` after McpDetection runs; CodexCollector
+    /// excludes these so a single mcp-server PID isn't double-counted
+    /// in the sessions panel.
+    pub mcp_server_pids: HashSet<u32>,
+    /// Rollout file paths held open by an mcp-server process. The
+    /// CodexCollector "recently finished" pass skips these to avoid
+    /// PID=0 ghost rows for threads that the mcp-server is still
+    /// holding fds for.
+    pub mcp_owned_rollouts: HashSet<PathBuf>,
+    /// When false, the suppression sets above are empty so the
+    /// sessions panel restores upstream behavior. Driven by the user
+    /// toggle (Shift+M).
+    pub mcp_suppress: bool,
 }
 
 impl SharedProcessData {
@@ -81,7 +98,15 @@ impl SharedProcessData {
             Some(p) => p.clone(),
             None => process::get_listening_ports(),
         };
-        Self { process_info, children_map, ports, slow_tick }
+        Self {
+            process_info,
+            children_map,
+            ports,
+            slow_tick,
+            mcp_server_pids: HashSet::new(),
+            mcp_owned_rollouts: HashSet::new(),
+            mcp_suppress: true,
+        }
     }
 }
 
@@ -106,6 +131,13 @@ pub struct MultiCollector {
     tracked_port_children: HashMap<u32, TrackedPortChild>,
     /// Detected orphan ports (updated each tick).
     pub orphan_ports: Vec<OrphanPort>,
+    /// MCP servers (codex mcp-server) detected on the most recent tick.
+    pub mcp_servers: Vec<McpServer>,
+    /// Whether to hide mcp-server-owned rollouts from the sessions
+    /// panel. When `false`, sessions panel reverts to upstream
+    /// behavior (mcp-server PIDs and their rollouts appear there too,
+    /// with the existing 1-of-N HashMap-overwrite caveat).
+    pub mcp_suppress: bool,
 }
 
 /// How often to refresh expensive I/O (in ticks). 5 ticks × 2s = 10s.
@@ -134,7 +166,13 @@ impl MultiCollector {
             cached_git: HashMap::new(),
             tracked_port_children: HashMap::new(),
             orphan_ports: Vec::new(),
+            mcp_servers: Vec::new(),
+            mcp_suppress: true,
         }
+    }
+
+    pub fn set_mcp_suppress(&mut self, on: bool) {
+        self.mcp_suppress = on;
     }
 
     /// Collect rate limit info from all registered collectors.
@@ -160,7 +198,7 @@ impl MultiCollector {
         current_pids.sort_unstable();
         let pids_changed = current_pids != self.cached_port_pids;
 
-        let shared = if slow_tick || pids_changed {
+        let mut shared = if slow_tick || pids_changed {
             let s = SharedProcessData::fetch(None, slow_tick);
             self.cached_ports = s.ports.clone();
             self.cached_port_pids = current_pids;
@@ -168,6 +206,16 @@ impl MultiCollector {
         } else {
             fresh_process
         };
+
+        // Detect MCP servers and stash the suppression sets in `shared`
+        // so CodexCollector can avoid double-counting their rollouts.
+        let detection = mcp::detect(&shared.process_info);
+        self.mcp_servers = detection.servers;
+        shared.mcp_suppress = self.mcp_suppress;
+        if self.mcp_suppress {
+            shared.mcp_server_pids = detection.server_pids;
+            shared.mcp_owned_rollouts = detection.owned_rollouts;
+        }
 
         let mut all = Vec::new();
         for collector in &mut self.collectors {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ pub struct PanelVisibility {
     pub projects: bool,
     pub ports: bool,
     pub sessions: bool,
+    pub mcp: bool,
 }
 
 impl Default for PanelVisibility {
@@ -19,6 +20,7 @@ impl Default for PanelVisibility {
             projects: true,
             ports: true,
             sessions: true,
+            mcp: true,
         }
     }
 }
@@ -84,6 +86,7 @@ pub fn load_config() -> AppConfig {
                 "show_projects" => config.panels.projects = parse_bool(val).unwrap_or(true),
                 "show_ports"    => config.panels.ports    = parse_bool(val).unwrap_or(true),
                 "show_sessions" => config.panels.sessions = parse_bool(val).unwrap_or(true),
+                "show_mcp"      => config.panels.mcp      = parse_bool(val).unwrap_or(true),
                 _ => {}
             }
         }
@@ -125,6 +128,7 @@ pub fn save_panel_visibility(panels: &PanelVisibility) -> Result<(), String> {
         ("show_projects", panels.projects.to_string()),
         ("show_ports",    panels.ports.to_string()),
         ("show_sessions", panels.sessions.to_string()),
+        ("show_mcp",      panels.mcp.to_string()),
     ])
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
                             KeyCode::Char('T') => app.tree_view = !app.tree_view,
                             KeyCode::Char('l') => app.toggle_timeline(),
                             KeyCode::Char('f') => app.toggle_file_audit(),
-                            KeyCode::Char(c @ '1'..='6') => app.toggle_panel(c as u8 - b'0'),
+                            KeyCode::Char(c @ '1'..='7') => app.toggle_panel(c as u8 - b'0'),
+                            KeyCode::Char('M') => app.toggle_mcp_session_suppression(),
                             KeyCode::Char('t') => app.cycle_theme(),
                             _ => {}
                         }
@@ -174,7 +175,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, demo_mode: boo
                             KeyCode::Char('t') => app.cycle_theme(),
                             KeyCode::Char('T') => app.tree_view = !app.tree_view,
                             KeyCode::Char('l') | KeyCode::Char('L') => app.toggle_timeline(),
-                            KeyCode::Char(c @ '1'..='6') => app.toggle_panel(c as u8 - b'0'),
+                            KeyCode::Char(c @ '1'..='7') => app.toggle_panel(c as u8 - b'0'),
+                            KeyCode::Char('M') => app.toggle_mcp_session_suppression(),
                             KeyCode::Char('c') => app.toggle_config(),
                             KeyCode::Char('v') => app.toggle_view_menu(),
                             KeyCode::Char('?') => app.toggle_help(),
@@ -232,7 +234,37 @@ fn sanitize_output(s: &str) -> String {
 }
 
 fn print_snapshot(app: &App) {
-    println!("abtop — {} sessions\n", app.sessions.len());
+    println!(
+        "abtop — {} sessions, {} mcp servers\n",
+        app.sessions.len(),
+        app.mcp_servers.len()
+    );
+    if !app.mcp_servers.is_empty() {
+        let now = std::time::SystemTime::now();
+        for server in &app.mcp_servers {
+            let active = server.active_count(now, collector::mcp::ACTIVE_MTIME_SECS);
+            let total = server.rollouts.len();
+            let last_age = server
+                .latest_mtime()
+                .and_then(|m| now.duration_since(m).ok())
+                .map(|d| {
+                    if d.as_secs() < 60 {
+                        format!("{}s", d.as_secs())
+                    } else if d.as_secs() < 3600 {
+                        format!("{}m", d.as_secs() / 60)
+                    } else {
+                        format!("{}h", d.as_secs() / 3600)
+                    }
+                })
+                .unwrap_or_else(|| "—".to_string());
+            let profile = server.profile.as_deref().unwrap_or("default");
+            println!(
+                "  mcp pid={} parent={} profile={:<16} active={}/{} last={}",
+                server.pid, server.parent_cli, profile, active, total, last_age
+            );
+        }
+        println!();
+    }
     for session in &app.sessions {
         let status = match &session.status {
             model::SessionStatus::Thinking => "◉ Think",

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -22,7 +22,8 @@ const ENTRIES: &[(&str, &str)] = &[
     ("  t / T",    "cycle theme / toggle tree"),
     ("  l",        "toggle timeline"),
     ("  f",        "toggle file audit"),
-    ("  1-6",      "toggle panels (context/quota/tokens/projects/ports/sessions)"),
+    ("  1-7",      "toggle panels (context/quota/tokens/projects/ports/sessions/mcp)"),
+    ("  M",        "toggle mcp-server suppression in sessions panel"),
     ("Help", ""),
     ("  ?",        "this help"),
 ];

--- a/src/ui/mcp.rs
+++ b/src/ui/mcp.rs
@@ -1,0 +1,106 @@
+use crate::app::App;
+use crate::collector::mcp::ACTIVE_MTIME_SECS;
+use crate::theme::Theme;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+use std::time::SystemTime;
+
+use super::{btop_block, grad_at, make_gradient};
+
+pub(crate) fn draw_mcp_panel(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
+    let header_style = Style::default()
+        .fg(theme.main_fg)
+        .add_modifier(Modifier::BOLD);
+    let mut lines = vec![Line::from(vec![
+        Span::styled(" PARENT  ", header_style),
+        Span::styled("PROFILE      ", header_style),
+        Span::styled("ACT/TOT ", header_style),
+        Span::styled("LAST", header_style),
+    ])];
+
+    if app.mcp_servers.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " no mcp servers",
+            Style::default().fg(theme.inactive_fg),
+        )));
+        let block = btop_block("mcp servers", "⁷", theme.net_box, theme);
+        f.render_widget(Paragraph::new(lines).block(block), area);
+        return;
+    }
+
+    let proc_grad = make_gradient(theme.proc_grad.start, theme.proc_grad.mid, theme.proc_grad.end);
+    let now = SystemTime::now();
+
+    for server in &app.mcp_servers {
+        let active = server.active_count(now, ACTIVE_MTIME_SECS);
+        let total = server.rollouts.len();
+        let last_age = server.latest_mtime().and_then(|m| now.duration_since(m).ok());
+
+        let active_color = if active > 0 {
+            grad_at(&proc_grad, 100.0)
+        } else if total > 0 {
+            theme.proc_misc
+        } else {
+            theme.inactive_fg
+        };
+        let count_text = format!("{:>3}/{:<3}", active, total);
+
+        let last_text = match last_age {
+            Some(d) => fmt_age(d.as_secs()),
+            None => "—".to_string(),
+        };
+
+        let parent_label = format!(" {:<7}", server.parent_cli);
+        let profile_label = match &server.profile {
+            Some(p) => super::truncate_str(p, 12),
+            None => "default".to_string(),
+        };
+        let profile_padded = format!("{:<13}", profile_label);
+
+        lines.push(Line::from(vec![
+            Span::styled(parent_label, Style::default().fg(theme.main_fg)),
+            Span::styled(profile_padded, Style::default().fg(theme.session_id)),
+            Span::styled(format!("{} ", count_text), Style::default().fg(active_color)),
+            Span::styled(last_text, Style::default().fg(theme.inactive_fg)),
+        ]));
+    }
+
+    if !app.mcp_suppress_sessions {
+        lines.push(Line::from(Span::styled(
+            " suppress: off (M)",
+            Style::default().fg(theme.inactive_fg),
+        )));
+    }
+
+    let block = btop_block("mcp servers", "⁷", theme.net_box, theme);
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+/// Format a duration into a compact "Xs / Xm / Xh" label.
+fn fmt_age(secs: u64) -> String {
+    if secs < 60 {
+        format!("{}s ago", secs)
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86400)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt_age_buckets() {
+        assert_eq!(fmt_age(5), "5s ago");
+        assert_eq!(fmt_age(125), "2m ago");
+        assert_eq!(fmt_age(7_200), "2h ago");
+        assert_eq!(fmt_age(172_800), "2d ago");
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ mod footer;
 mod header;
 mod help;
 mod view_menu;
+mod mcp;
 mod ports;
 mod projects;
 mod quota;
@@ -298,7 +299,7 @@ pub fn draw(f: &mut Frame, app: &App) {
     const CONTEXT_MIN: u16 = 5;
     const FIXED: u16 = 2; // header + footer
 
-    let any_mid = app.show_quota || app.show_tokens || app.show_projects || app.show_ports;
+    let any_mid = app.show_quota || app.show_tokens || app.show_projects || app.show_ports || app.show_mcp;
 
     let mid_h_ideal: u16 = 8;
     let sessions_ideal: u16 = if app.show_sessions {
@@ -367,6 +368,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         if app.show_tokens { mid_constraints.push(Constraint::Length(0)); }
         if app.show_projects { mid_constraints.push(Constraint::Length(0)); }
         if app.show_ports { mid_constraints.push(Constraint::Length(0)); }
+        if app.show_mcp { mid_constraints.push(Constraint::Length(0)); }
         let count = mid_constraints.len() as u32;
         let mid_constraints: Vec<Constraint> = (0..count).map(|_| Constraint::Ratio(1, count)).collect();
 
@@ -379,7 +381,8 @@ pub fn draw(f: &mut Frame, app: &App) {
         if app.show_quota { quota::draw_quota_panel(f, app, mid_panels[mi], theme); mi += 1; }
         if app.show_tokens { tokens::draw_tokens_panel(f, app, mid_panels[mi], theme); mi += 1; }
         if app.show_projects { projects::draw_projects_panel(f, app, mid_panels[mi], theme); mi += 1; }
-        if app.show_ports { ports::draw_ports_panel(f, app, mid_panels[mi], theme); }
+        if app.show_ports { ports::draw_ports_panel(f, app, mid_panels[mi], theme); mi += 1; }
+        if app.show_mcp { mcp::draw_mcp_panel(f, app, mid_panels[mi], theme); }
         idx += 1;
     }
 

--- a/src/ui/view_menu.rs
+++ b/src/ui/view_menu.rs
@@ -34,6 +34,8 @@ pub(crate) fn items(app: &App) -> Vec<ViewItem> {
         ViewItem { key: '4', label: "projects panel",  state: bool_state(app.show_projects) },
         ViewItem { key: '5', label: "ports panel",     state: bool_state(app.show_ports) },
         ViewItem { key: '6', label: "sessions panel",  state: bool_state(app.show_sessions) },
+        ViewItem { key: '7', label: "mcp servers panel", state: bool_state(app.show_mcp) },
+        ViewItem { key: 'M', label: "mcp session hide", state: bool_state(app.mcp_suppress_sessions) },
         ViewItem { key: 't', label: "cycle theme",     state: Action },
     ]
 }


### PR DESCRIPTION
Closes / refs #95.

## What this does

Adds a process-driven **MCP servers** panel that surfaces every running `codex mcp-server` and the rollouts it currently holds open. By default, mcp-server-owned rollouts are excluded from the sessions panel, fixing the PID=0 "Done" ghosts and the silent-overwrite drop documented in #95.

## Disclosure: which option from #95 I implemented and why

#95 listed three rough directions; this PR implements **(b)** — the new process-driven panel.

I chose (b) over (a) because (a) — making the sessions panel handle 1 PID → N rollouts — would have broken every PID-scoped operation in abtop:
- `x` SIGKILL would kill all in-process threads at once with no UI signal of the connection
- `mem_mb` would double-count across rows that share a PID
- `children`/ports would duplicate to every row that shares a PID
- status detection would be permanently wrong because the PID never dies and finished threads keep their fds open

I deliberately did **not** fix the multi-rollout `HashMap<u32, PathBuf>` overwrite in `CodexCollector::map_pid_to_jsonl`. That fix only makes sense in option (a), and (a) hits the dysfunction above. If you'd prefer (a) or a hybrid, I'm happy to rework — flagging it explicitly here so the choice is on the table rather than buried in a diff.

I did not pursue (c) (push fd-recycling into codex). Keeping fds open is plausibly an intentional codex design choice for thread resume, not a bug — see the discussion in #95.

## Behavior

- New `collector::mcp` module detects `codex mcp-server` processes from the shared `ps` snapshot. Per PID, it lists every open `rollout-*.jsonl` fd (Linux: `/proc/{pid}/fd`; macOS: `lsof`; Windows: `sysinfo`).
- "Active" rollouts use a 30s mtime threshold (`ACTIVE_MTIME_SECS`). Fd presence alone overcounts: on my box, two mcp-servers each held 4–5 rollouts spanning hours, only the most recent of which was actually being written to.
- Panel columns: parent CLI (`claude`/`codex`/`?`), `-c profile=` value (or `default`), `active/total` rollout count, age of latest rollout mtime. Idle mcp-servers (no rollouts) show `0/0 —` so users can still see "Claude has launched the cheap MCP".
- `CodexCollector` skips mcp-server PIDs in its active pass and skips mcp-owned rollouts in the recently-finished pass, removing the PID=0 ghost rows. Pass-through via `SharedProcessData` so the sets are computed once per tick.
- Toggle `7` shows/hides the panel (added to view menu, config overlay, persisted in `~/.config/abtop/config.toml`).
- Toggle `M` flips mcp-server-owned rollouts back into the sessions panel for debugging — with the existing 1-of-N HashMap-overwrite caveat unchanged.
- `--once` prints an MCP server section.

## Verified locally

```
$ abtop --once
abtop — 8 sessions, 14 mcp servers

  mcp pid=17870 parent=claude profile=qwen36-litellm   active=0/4 last=1h
  mcp pid=30022 parent=claude profile=default          active=0/5 last=54m
  mcp pid=46305 parent=claude profile=default          active=0/4 last=9h
  ...
```

`cargo test` passes (103 tests, including 6 new ones for `mcp::detect`, profile parsing, parent-CLI resolution, and active-mtime threshold). `cargo clippy --all-targets` shows only the pre-existing `items_after_test_module` warning in `src/ui/sessions.rs` that's already on `main`.

## Files

- `src/collector/mcp.rs` (new) — detection + multi-rollout fd mapping
- `src/ui/mcp.rs` (new) — panel renderer
- `src/collector/mod.rs` — wires McpDetection into MultiCollector + SharedProcessData
- `src/collector/codex.rs` — sessions-panel suppression hooks
- `src/app.rs` — `show_mcp` + `mcp_servers` + `mcp_suppress_sessions` + toggles
- `src/config.rs` — `show_mcp` persistence
- `src/main.rs` — `1`-`7` panel range, `M` suppression toggle, `--once` MCP section
- `src/ui/{mod,view_menu,help}.rs` — register panel + help/menu entries