### PR TITLE
fix(windows): resolve Codex CLI session discovery on Windows

### DIFF
--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -323,6 +323,10 @@ impl CodexCollector {
     /// equivalent of lsof for enumerating open file descriptors.
     /// Falls back to lsof on macOS/other platforms.
     fn map_pid_to_jsonl(pids: &[u32], sessions_dir: &Path) -> HashMap<u32, PathBuf> {
+        // sessions_dir is consumed only by the windows arm below.
+        #[cfg(not(target_os = "windows"))]
+        let _ = sessions_dir;
+
         let mut map = HashMap::new();
         if pids.is_empty() {
             return map;

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -52,7 +52,7 @@ impl CodexCollector {
             &shared.mcp_server_pids,
         );
         let just_pids: Vec<u32> = codex_pids.iter().map(|(p, _)| *p).collect();
-        let pid_to_jsonl = Self::map_pid_to_jsonl(&just_pids);
+        let pid_to_jsonl = Self::map_pid_to_jsonl(&just_pids, &self.sessions_dir);
         let pid_is_exec: HashMap<u32, bool> = codex_pids.into_iter().collect();
 
         let mut sessions = Vec::new();
@@ -318,9 +318,11 @@ impl CodexCollector {
     /// Map codex PIDs to their open rollout-*.jsonl files.
     ///
     /// On Linux, scans /proc/{pid}/fd symlinks directly (no process spawn).
-    /// On Windows, uses sysinfo to get process cwd then scans for rollout files.
+    /// On Windows, scans ~/.codex/sessions/YYYY/MM/DD/ for recently modified
+    /// JSONL files and assigns them to discovered PIDs, since Windows has no
+    /// equivalent of lsof for enumerating open file descriptors.
     /// Falls back to lsof on macOS/other platforms.
-    fn map_pid_to_jsonl(pids: &[u32]) -> HashMap<u32, PathBuf> {
+    fn map_pid_to_jsonl(pids: &[u32], sessions_dir: &Path) -> HashMap<u32, PathBuf> {
         let mut map = HashMap::new();
         if pids.is_empty() {
             return map;
@@ -345,30 +347,40 @@ impl CodexCollector {
 
         #[cfg(target_os = "windows")]
         {
-            let mut sys = sysinfo::System::new();
-            let pids_sys: Vec<sysinfo::Pid> = pids.iter().copied().map(|p| sysinfo::Pid::from(p as usize)).collect();
-            sys.refresh_processes_specifics(
-                sysinfo::ProcessesToUpdate::Some(&pids_sys),
-                true,
-                sysinfo::ProcessRefreshKind::new().with_memory(),
-            );
-            for &pid_u32 in pids {
-                let pid = sysinfo::Pid::from(pid_u32 as usize);
-                if let Some(proc_) = sys.process(pid) {
-                    if let Some(cwd) = proc_.cwd() {
-                        if let Ok(entries) = fs::read_dir(&cwd) {
-                            for entry in entries.flatten() {
-                                let name = entry.file_name();
-                                let name_str = name.to_string_lossy();
-                                if name_str.starts_with("rollout-") && name_str.ends_with(".jsonl") {
-                                    map.insert(pid_u32, entry.path());
-                                    break;
-                                }
+            // Windows has no lsof or /proc/{pid}/fd to map PIDs to open files.
+            // Instead, scan today's ~/.codex/sessions/YYYY/MM/DD/ directory for
+            // rollout-*.jsonl files, then assign them to discovered codex PIDs.
+            // Prefer recently modified files, but fall back to any today's file
+            // since Codex may be idle (waiting for input) and not actively writing.
+            let mut candidates: Vec<(PathBuf, std::time::SystemTime)> = Vec::new();
+
+            if let Some(today_dir) = Self::today_session_dir(sessions_dir) {
+                if let Ok(entries) = fs::read_dir(&today_dir) {
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                        if !name.starts_with("rollout-") || !name.ends_with(".jsonl") {
+                            continue;
+                        }
+                        if let Ok(meta) = fs::metadata(&path) {
+                            if let Ok(modified) = meta.modified() {
+                                candidates.push((path, modified));
                             }
                         }
                     }
                 }
             }
+
+            // Sort by modification time descending (most recent first)
+            candidates.sort_by(|a, b| b.1.cmp(&a.1));
+
+            // Assign candidates to PIDs (most recent file → first PID)
+            for (i, &pid_u32) in pids.iter().enumerate() {
+                if i < candidates.len() {
+                    map.insert(pid_u32, candidates[i].0.clone());
+                }
+            }
+
             map
         }
 

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -377,16 +377,22 @@ pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     })
 }
 
-/// Windows variant: also splits on `\`, strips a trailing `.exe`, and matches
-/// case-insensitively. Kept separate from the unix impl so non-Windows
-/// matching stays exact (`Claude` must not match `claude` on linux/macOS).
+/// Windows variant: also splits on `\`, strips a trailing `.exe` and common
+/// script extensions (`.js`, `.sh`, `.py`), and matches case-insensitively.
+/// Kept separate from the unix impl so non-Windows matching stays exact
+/// (`Claude` must not match `claude` on linux/macOS).
 #[cfg(windows)]
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     let mut tokens = cmd.split_whitespace().take(2);
     tokens.any(|tok| {
         let mut iter = tok.rsplit(['/', '\\']);
         let base = iter.next().unwrap_or(tok);
-        let base = base.strip_suffix(".exe").unwrap_or(base);
+        let base = base
+            .strip_suffix(".exe")
+            .or_else(|| base.strip_suffix(".js"))
+            .or_else(|| base.strip_suffix(".sh"))
+            .or_else(|| base.strip_suffix(".py"))
+            .unwrap_or(base);
         if base.eq_ignore_ascii_case(name) {
             return true;
         }


### PR DESCRIPTION
## Summary

- Fix `map_pid_to_jsonl` Windows branch to scan `~/.codex/sessions/YYYY/MM/DD/` instead of the process CWD (which never contains rollout files)
- Fix `cmd_has_binary` Windows variant to strip `.js`/`.sh`/`.py` extensions so `node.exe ... codex.js` correctly matches `codex`

## Problem

On Windows, abtop could never discover active Codex CLI sessions due to two bugs:

1. **Wrong scan directory**: The Windows `map_pid_to_jsonl` used `sysinfo` to get the process CWD, then scanned it for `rollout-*.jsonl`. But Codex stores JSONL files in `~/.codex/sessions/YYYY/MM/DD/`, not in the project working directory. Linux works because `/proc/{pid}/fd` resolves open file symlinks regardless of path.

2. **Process name mismatch**: `cmd_has_binary("codex")` failed because Codex CLI runs as `node.exe ... codex.js`. The Windows variant only stripped `.exe`, so basename `codex.js` ≠ `codex`.

## Changes

- `src/collector/codex.rs`: Replace CWD-based scanning with `today_session_dir()` scanning, assigning JSONL files to PIDs by modification time
- `src/collector/process.rs`: Add `.js`, `.sh`, `.py` extension stripping on the Windows `cmd_has_binary` path

## Test plan

- [x] `cargo test collector::codex` — all 14 tests pass
- [x] `cargo test collector::process` — all 3 tests pass
- [x] `cargo build --release` — compiles cleanly on Windows 11
- [x] `abtop --once` shows both Claude Code and Codex CLI sessions simultaneously
- [x] Manual TUI verification (`abtop`) with Codex actively running

🤖 Generated with [Claude Code](https://claude.com/claude-code)