### PR TITLE
feat(config): add language key to config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,18 @@ theme = "btop"
 # Hide specific agent CLIs from the TUI (case-insensitive).
 # Useful if you only use one agent and want a cleaner view.
 hidden_agents = ["codex"]
+# UI language. Omit or leave empty to auto-detect from LANG.
+language = "zh"
 ```
 
-### Language
+### Supported Languages
 
-abtop auto-detects the UI language from `LANG` — any value starting with `zh` switches to Simplified Chinese, otherwise English. Override with `ABTOP_LANG=zh` or `ABTOP_LANG=en`.
+| Code | Language            |
+| ---- | ------------------- |
+| `en` | English (default)   |
+| `zh` | Simplified Chinese  |
+
+When `language` is unset, abtop auto-detects from `LANG` — any value starting with `zh` switches to Simplified Chinese, otherwise English.
 
 ## Key Bindings
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,9 @@ pub struct AppConfig {
     /// Matched case-insensitively against each collector's agent_cli identifier.
     pub hidden_agents: Vec<String>,
     pub panels: PanelVisibility,
+    /// UI language override. Empty string means auto-detect from `LANG`.
+    /// Recognized values: "en", "zh" (anything starting with "zh" maps to Simplified Chinese).
+    pub language: String,
 }
 
 impl Default for AppConfig {
@@ -39,6 +42,7 @@ impl Default for AppConfig {
             theme: "btop".to_string(),
             hidden_agents: Vec::new(),
             panels: PanelVisibility::default(),
+            language: String::new(),
         }
     }
 }
@@ -80,6 +84,7 @@ pub fn load_config() -> AppConfig {
             let val = val.trim_matches('"').trim_matches('\'');
             match key {
                 "theme" => config.theme = val.to_string(),
+                "language" => config.language = val.to_string(),
                 "show_context" => config.panels.context = parse_bool(val).unwrap_or(true),
                 "show_quota" => config.panels.quota = parse_bool(val).unwrap_or(true),
                 "show_tokens" => config.panels.tokens = parse_bool(val).unwrap_or(true),
@@ -258,5 +263,15 @@ mod tests {
         assert_eq!(parse_bool("true"), Some(true));
         assert_eq!(parse_bool("False"), Some(false));
         assert_eq!(parse_bool("nope"), None);
+    }
+
+    #[test]
+    fn rewrite_language_replaces_existing() {
+        let before = "theme = \"btop\"\nlanguage = \"en\"\n";
+        let updates: Vec<(&str, String)> = vec![("language", "\"zh\"".to_string())];
+        let after = rewrite_kv_lines(before, &updates);
+        assert!(after.contains("language = \"zh\""));
+        assert!(!after.contains("language = \"en\""));
+        assert!(after.contains("theme = \"btop\""));
     }
 }

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -3,9 +3,12 @@ use std::env;
 use std::sync::LazyLock;
 
 static CURRENT_LANG: LazyLock<&str> = LazyLock::new(|| {
-    let lang = env::var("ABTOP_LANG")
-        .or_else(|_| env::var("LANG"))
-        .unwrap_or_default();
+    let from_config = crate::config::load_config().language;
+    let lang = if !from_config.is_empty() {
+        from_config
+    } else {
+        env::var("LANG").unwrap_or_default()
+    };
     if lang.to_lowercase().starts_with("zh") {
         "zh-CN"
     } else {


### PR DESCRIPTION
## Summary
- Add `language` key to `~/.config/abtop/config.toml` so users can pick the UI language without exporting an env var on every run.
- Drop the (undocumented) `ABTOP_LANG` env var in favor of the config file as the single user-facing surface. `LANG`-based auto-detection is unchanged.
- README: add a "Supported Languages" table (`en`, `zh`) and show `language = "zh"` in the example config block.

## Resolution order
1. `language` in `config.toml` (new)
2. `LANG` env var (unchanged)
3. fallback: `en`

## Test plan
- [x] `cargo build`
- [x] `cargo clippy -- -D warnings` (matches CI)
- [x] `cargo test` — 104 pass, including the new `rewrite_language_replaces_existing` round-trip test
- [ ] Manual: `language = "zh"` in config switches UI to Simplified Chinese; `language = "en"` overrides a `LANG=zh_CN.UTF-8` shell back to English; omitting the key falls back to `LANG`.