### PR TITLE
fix(quota): clarify the panel — drop ambiguous freshness, label reset countdown

### DIFF
--- a/src/locale.rs
+++ b/src/locale.rs
@@ -199,7 +199,6 @@ static LOCALE_EN: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("quota.abtop_setup", "abtop --setup");
     m.insert("quota.run_codex", "run codex once");
     m.insert("quota.total", "total");
-    m.insert("quota.now", "now");
     m.insert("quota.in", "in");
 
     // Projects panel
@@ -441,7 +440,6 @@ static LOCALE_ZH: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("quota.abtop_setup", "abtop --setup");
     m.insert("quota.run_codex", "运行一次 codex");
     m.insert("quota.total", "总计");
-    m.insert("quota.now", "现在");
     m.insert("quota.in", "还有");
 
     // Projects panel

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -200,7 +200,6 @@ static LOCALE_EN: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("quota.run_codex", "run codex once");
     m.insert("quota.total", "total");
     m.insert("quota.now", "now");
-    m.insert("quota.ago", "ago");
 
     // Projects panel
     m.insert("projects.no_git", "no git");
@@ -442,7 +441,6 @@ static LOCALE_ZH: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("quota.run_codex", "运行一次 codex");
     m.insert("quota.total", "总计");
     m.insert("quota.now", "现在");
-    m.insert("quota.ago", "前");
 
     // Projects panel
     m.insert("projects.no_git", "非 Git");

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -200,6 +200,7 @@ static LOCALE_EN: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("quota.run_codex", "run codex once");
     m.insert("quota.total", "total");
     m.insert("quota.now", "now");
+    m.insert("quota.in", "in");
 
     // Projects panel
     m.insert("projects.no_git", "no git");
@@ -441,6 +442,7 @@ static LOCALE_ZH: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("quota.run_codex", "运行一次 codex");
     m.insert("quota.total", "总计");
     m.insert("quota.now", "现在");
+    m.insert("quota.in", "还有");
 
     // Projects panel
     m.insert("projects.no_git", "非 Git");

--- a/src/ui/mcp.rs
+++ b/src/ui/mcp.rs
@@ -9,7 +9,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 use std::time::SystemTime;
 
-use super::{btop_block, grad_at, make_gradient};
+use super::{btop_block, fmt_age, grad_at, make_gradient};
 
 pub(crate) fn draw_mcp_panel(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
     let header_style = Style::default()
@@ -96,30 +96,3 @@ pub(crate) fn draw_mcp_panel(f: &mut Frame, app: &App, area: Rect, theme: &Theme
     f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-/// Format a duration into a compact "Xs / Xm / Xh" label.
-fn fmt_age(secs: u64) -> String {
-    if secs < 60 {
-        format!("{}{}", secs, t("time.s_ago"))
-    } else if secs < 3600 {
-        format!("{}{}", secs / 60, t("time.m_ago"))
-    } else if secs < 86400 {
-        format!("{}{}", secs / 3600, t("time.h_ago"))
-    } else {
-        format!("{}{}", secs / 86400, t("time.d_ago"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn fmt_age_buckets() {
-        // t() defaults to English when ABTOP_LANG is unset, so the strings
-        // here match the en-US locale values for `time.{s,m,h,d}_ago`.
-        assert_eq!(fmt_age(5), "5s ago");
-        assert_eq!(fmt_age(125), "2m ago");
-        assert_eq!(fmt_age(7_200), "2h ago");
-        assert_eq!(fmt_age(172_800), "2d ago");
-    }
-}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -518,6 +518,19 @@ pub(crate) fn fmt_tokens(n: u64) -> String {
     }
 }
 
+/// Format a duration in seconds into a compact "Ns / Nm / Nh / Nd ago" label.
+pub(crate) fn fmt_age(secs: u64) -> String {
+    if secs < 60 {
+        format!("{}{}", secs, t("time.s_ago"))
+    } else if secs < 3600 {
+        format!("{}{}", secs / 60, t("time.m_ago"))
+    } else if secs < 86400 {
+        format!("{}{}", secs / 3600, t("time.h_ago"))
+    } else {
+        format!("{}{}", secs / 86400, t("time.d_ago"))
+    }
+}
+
 pub(crate) fn truncate_str(s: &str, max: usize) -> String {
     if max == 0 {
         return String::new();
@@ -527,5 +540,24 @@ pub(crate) fn truncate_str(s: &str, max: usize) -> String {
     } else {
         let truncated: String = s.chars().take(max - 1).collect();
         format!("{}…", truncated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt_age_buckets() {
+        // t() defaults to English when ABTOP_LANG is unset, so the strings
+        // here match the en-US locale values for `time.{s,m,h,d}_ago`.
+        assert_eq!(fmt_age(5), "5s ago");
+        assert_eq!(fmt_age(59), "59s ago");
+        assert_eq!(fmt_age(60), "1m ago");
+        assert_eq!(fmt_age(125), "2m ago");
+        assert_eq!(fmt_age(7_200), "2h ago");
+        // Regression: the quota panel used to render this raw as "341493ago"
+        // because it formatted seconds without unit conversion.
+        assert_eq!(fmt_age(341_493), "3d ago");
     }
 }

--- a/src/ui/quota.rs
+++ b/src/ui/quota.rs
@@ -150,12 +150,20 @@ fn draw_source_column(
             .add_modifier(Modifier::BOLD),
     )));
 
+    // Reset countdown is only meaningful when the data is fresh enough
+    // that the reported `resets_at` is still in the future. Stale sources
+    // get the bar (the % is approximately correct) but no countdown row.
+    let show_reset = !is_stale;
+
     if let Some(used_pct) = rl.five_hour_pct {
         let remaining = (100.0 - used_pct).clamp(0.0, 100.0);
-        let reset = rl
-            .five_hour_resets_at
-            .map(format_reset_time)
-            .unwrap_or_default();
+        let reset = if show_reset {
+            rl.five_hour_resets_at
+                .map(format_reset_time)
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
         let c = grad_at(cpu_grad, used_pct);
         let label_5h = t("quota.5h");
         let mut s = vec![styled_label(
@@ -177,10 +185,13 @@ fn draw_source_column(
     }
     if let Some(used_pct) = rl.seven_day_pct {
         let remaining = (100.0 - used_pct).clamp(0.0, 100.0);
-        let reset = rl
-            .seven_day_resets_at
-            .map(format_reset_time)
-            .unwrap_or_default();
+        let reset = if show_reset {
+            rl.seven_day_resets_at
+                .map(format_reset_time)
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
         let c = grad_at(cpu_grad, used_pct);
         let label_7d = t("quota.7d");
         let mut s = vec![styled_label(
@@ -205,16 +216,19 @@ fn draw_source_column(
 }
 
 /// Format a reset timestamp as a human countdown labeled "in X" so the
-/// row reads as a time-until-reset rather than an ambiguous duration.
-/// When the reset moment is at or in the past, returns the localized
-/// "now" sentinel without the prefix.
+/// row reads as a time-until-reset. Returns an empty string when the
+/// reset is already in the past — the actual next reset depends on the
+/// window length which the caller doesn't track, and showing a "now"
+/// sentinel was misleading on stale sources where the window had
+/// already rolled over multiple times. Callers skip the row when this
+/// returns empty.
 pub(crate) fn format_reset_time(reset_ts: u64) -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
     if reset_ts <= now {
-        return t("quota.now");
+        return String::new();
     }
     let diff = reset_ts - now;
     let prefix = t("quota.in");

--- a/src/ui/quota.rs
+++ b/src/ui/quota.rs
@@ -8,7 +8,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
-use super::{btop_block, fmt_tokens, grad_at, make_gradient, remaining_bar, styled_label};
+use super::{btop_block, fmt_age, fmt_tokens, grad_at, make_gradient, remaining_bar, styled_label};
 
 /// Data considered "stale" when its updated_at is older than this many seconds.
 const STALE_SECS: u64 = 600;
@@ -131,10 +131,7 @@ fn draw_source_column(
     let ago_secs = rl.updated_at.map(|ts| now.saturating_sub(ts));
     let is_stale = ago_secs.is_some_and(|s| s > STALE_SECS);
 
-    let ago_label = t("quota.ago");
-    let fresh_str = ago_secs
-        .map(|s| format!("{}{}", s, ago_label))
-        .unwrap_or_default();
+    let fresh_str = ago_secs.map(fmt_age).unwrap_or_default();
     let fresh_color = if is_stale {
         theme.inactive_fg
     } else {

--- a/src/ui/quota.rs
+++ b/src/ui/quota.rs
@@ -8,7 +8,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
-use super::{btop_block, fmt_age, fmt_tokens, grad_at, make_gradient, remaining_bar, styled_label};
+use super::{btop_block, fmt_tokens, grad_at, make_gradient, remaining_bar, styled_label};
 
 /// Data considered "stale" when its updated_at is older than this many seconds.
 const STALE_SECS: u64 = 600;
@@ -128,32 +128,27 @@ fn draw_source_column(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let ago_secs = rl.updated_at.map(|ts| now.saturating_sub(ts));
-    let is_stale = ago_secs.is_some_and(|s| s > STALE_SECS);
+    let is_stale = rl
+        .updated_at
+        .is_some_and(|ts| now.saturating_sub(ts) > STALE_SECS);
 
-    let fresh_str = ago_secs.map(fmt_age).unwrap_or_default();
-    let fresh_color = if is_stale {
+    // Stale data → dim the source name. Drops the unlabeled "Xs ago" row
+    // we used to render here; keeping a distinct freshness color but no
+    // explicit number is enough to signal "values may be out of date"
+    // without competing with the reset countdown for the user's attention.
+    let source_color = if is_stale {
         theme.inactive_fg
     } else {
-        theme.graph_text
+        theme.title
     };
 
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
         format!(" {}", rl.source.to_uppercase()),
         Style::default()
-            .fg(theme.title)
+            .fg(source_color)
             .add_modifier(Modifier::BOLD),
     )));
-    // Freshness on its own indented line so the full "Ns/m/h/d ago"
-    // string fits without truncation when the column is narrow
-    // (panels share width and the per-column budget is ~10 chars).
-    if !fresh_str.is_empty() {
-        lines.push(Line::from(Span::styled(
-            format!("  {}", fresh_str),
-            Style::default().fg(fresh_color),
-        )));
-    }
 
     if let Some(used_pct) = rl.five_hour_pct {
         let remaining = (100.0 - used_pct).clamp(0.0, 100.0);
@@ -209,7 +204,10 @@ fn draw_source_column(
     f.render_widget(Paragraph::new(lines), area);
 }
 
-/// Format a reset timestamp as relative time (e.g., "1h 23m")
+/// Format a reset timestamp as a human countdown labeled "in X" so the
+/// row reads as a time-until-reset rather than an ambiguous duration.
+/// When the reset moment is at or in the past, returns the localized
+/// "now" sentinel without the prefix.
 pub(crate) fn format_reset_time(reset_ts: u64) -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -219,21 +217,18 @@ pub(crate) fn format_reset_time(reset_ts: u64) -> String {
         return t("quota.now");
     }
     let diff = reset_ts - now;
+    let prefix = t("quota.in");
     if diff < 60 {
-        format!("{}{}", diff, t("time.s"))
+        format!("{} {}{}", prefix, diff, t("time.s"))
     } else if diff < 3600 {
-        format!("{}{}", diff / 60, t("time.m"))
+        format!("{} {}{}", prefix, diff / 60, t("time.m"))
     } else if diff < 86400 {
         let h = diff / 3600;
         let m = (diff % 3600) / 60;
-        let h_label = t("time.h");
-        let m_label = t("time.m");
-        format!("{}{} {}{}", h, h_label, m, m_label)
+        format!("{} {}{} {}{}", prefix, h, t("time.h"), m, t("time.m"))
     } else {
         let d = diff / 86400;
         let h = (diff % 86400) / 3600;
-        let d_label = t("time.d");
-        let h_label = t("time.h");
-        format!("{}{} {}{}", d, d_label, h, h_label)
+        format!("{} {}{} {}{}", prefix, d, t("time.d"), h, t("time.h"))
     }
 }

--- a/src/ui/quota.rs
+++ b/src/ui/quota.rs
@@ -176,12 +176,17 @@ fn draw_source_column(
             Style::default().fg(c),
         ));
         lines.push(Line::from(s));
-        if !reset.is_empty() {
-            lines.push(Line::from(Span::styled(
-                format!("  {}", reset),
-                Style::default().fg(theme.graph_text),
-            )));
-        }
+        // Always reserve the row so both columns line up vertically;
+        // when there's nothing meaningful to show (stale source or the
+        // cached reset moment is past), render it blank.
+        lines.push(Line::from(Span::styled(
+            if reset.is_empty() {
+                String::new()
+            } else {
+                format!("  {}", reset)
+            },
+            Style::default().fg(theme.graph_text),
+        )));
     }
     if let Some(used_pct) = rl.seven_day_pct {
         let remaining = (100.0 - used_pct).clamp(0.0, 100.0);
@@ -204,12 +209,17 @@ fn draw_source_column(
             Style::default().fg(c),
         ));
         lines.push(Line::from(s));
-        if !reset.is_empty() {
-            lines.push(Line::from(Span::styled(
-                format!("  {}", reset),
-                Style::default().fg(theme.graph_text),
-            )));
-        }
+        // Always reserve the row so both columns line up vertically;
+        // when there's nothing meaningful to show (stale source or the
+        // cached reset moment is past), render it blank.
+        lines.push(Line::from(Span::styled(
+            if reset.is_empty() {
+                String::new()
+            } else {
+                format!("  {}", reset)
+            },
+            Style::default().fg(theme.graph_text),
+        )));
     }
 
     f.render_widget(Paragraph::new(lines), area);

--- a/src/ui/quota.rs
+++ b/src/ui/quota.rs
@@ -139,16 +139,21 @@ fn draw_source_column(
     };
 
     let mut lines: Vec<Line> = Vec::new();
-    let mut label_spans = vec![Span::styled(
+    lines.push(Line::from(Span::styled(
         format!(" {}", rl.source.to_uppercase()),
         Style::default()
             .fg(theme.title)
             .add_modifier(Modifier::BOLD),
-    )];
+    )));
+    // Freshness on its own indented line so the full "Ns/m/h/d ago"
+    // string fits without truncation when the column is narrow
+    // (panels share width and the per-column budget is ~10 chars).
     if !fresh_str.is_empty() {
-        label_spans.push(Span::styled(fresh_str, Style::default().fg(fresh_color)));
+        lines.push(Line::from(Span::styled(
+            format!("  {}", fresh_str),
+            Style::default().fg(fresh_color),
+        )));
     }
-    lines.push(Line::from(label_spans));
 
     if let Some(used_pct) = rl.five_hour_pct {
         let remaining = (100.0 - used_pct).clamp(0.0, 100.0);


### PR DESCRIPTION
## Summary
The quota panel rendered three different time strings per column with no labels (`42s ago` over the source, `42m` under each bar, and a bare `now` when the reset cache was past) — the user couldn't tell which was data freshness vs reset countdown, and `now` actively misled on stale sources where the window had already rolled over multiple times. Cleaned up so the panel only shows one labeled time per row, and only when it's actually meaningful.

## Changes
- Promote `fmt_age` from `src/ui/mcp.rs` to `src/ui/mod.rs` so panels share a humanizer (drops the now-unused `quota.ago` locale key).
- Drop the unlabeled `Xs ago` freshness row entirely. Stale data (>10 min since update) is signaled by dimming the source name in `inactive_fg`.
- Reset countdown reads as `in 42m` / `in 5d 18h`. Adds `quota.in` (en: `in`, zh: `还有`).
- Hide the reset row instead of rendering `now`:
  - When the source is stale, suppress the countdown for the whole column (the reported `resets_at` is no longer trustworthy).
  - When `reset_ts <= now`, return an empty string so the row is skipped — the actual next reset depends on the window length which the panel doesn't track.
  - Removes the `quota.now` locale key.

## After
Fresh source (claude data fresh):
```
 CLAUDE
5h▒▒▒▒ 95%
  in 42m
7d▒▒▒▒ 97%
  in 5d 18h
```

Stale source (codex session 3 days old): heading dims, countdown rows disappear, bars stay so you can still see the last-known %.

## Test plan
- [x] `cargo build`
- [x] `cargo test` — 114 pass
- [ ] Run abtop locally and confirm: fresh source shows `in 42m` / `in 5d 18h`; stale source has a dimmed heading and no reset rows; `now` no longer appears.