### PR TITLE
fix(windows): detect node-wrapped Codex commands

### DIFF
--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -312,6 +312,25 @@ impl CodexCollector {
                 pids.push((*pid, is_exec));
             }
         }
+
+        // Windows npm/Git shims can create a chain like:
+        // sh.exe -> node.exe ...\codex.js -> codex.exe.
+        // Once the real codex child exists, keep that child and drop wrapper
+        // ancestors; otherwise Windows rollout fallback maps each candidate PID
+        // to a different recent JSONL file and historical sessions look live.
+        let candidates = pids.clone();
+        pids.retain(|(pid, _)| {
+            process::cmd_first_token_has_binary(
+                process_info
+                    .get(pid)
+                    .map(|info| info.command.as_str())
+                    .unwrap_or_default(),
+                "codex",
+            ) || !candidates.iter().any(|(other_pid, _)| {
+                *other_pid != *pid && process::is_descendant_of(*other_pid, *pid, process_info)
+            })
+        });
+
         pids
     }
 
@@ -950,6 +969,53 @@ mod tests {
             writeln!(file, "{}", line).unwrap();
         }
         file.flush().unwrap();
+    }
+
+    fn proc_info(pid: u32, ppid: u32, command: &str) -> ProcInfo {
+        ProcInfo {
+            pid,
+            ppid,
+            rss_kb: 0,
+            cpu_pct: 0.0,
+            command: command.to_string(),
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn find_codex_pids_windows_keeps_real_child_over_wrappers() {
+        let mut process_info = HashMap::new();
+        process_info.insert(
+            10,
+            proc_info(
+                10,
+                1,
+                r#""C:\Program Files\Git\usr\bin\sh.exe" /c/Users/GK/AppData/Roaming/npm/codex -m gpt-5.5"#,
+            ),
+        );
+        process_info.insert(
+            20,
+            proc_info(
+                20,
+                10,
+                r#""C:\Program Files\nodejs\node.exe" C:\Users\GK\AppData\Roaming\npm\node_modules\@openai\codex\bin\codex.js -m gpt-5.5"#,
+            ),
+        );
+        process_info.insert(
+            30,
+            proc_info(
+                30,
+                20,
+                r#"C:\Users\GK\AppData\Roaming\npm\node_modules\@openai\codex\node_modules\@openai\codex-win32-x64\vendor\x86_64-pc-windows-msvc\codex\codex.exe -m gpt-5.5"#,
+            ),
+        );
+
+        let pids = CodexCollector::find_codex_pids_from_shared(
+            &process_info,
+            &std::collections::HashSet::new(),
+        );
+
+        assert_eq!(pids, vec![(30, false)]);
     }
 
     #[test]

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -971,6 +971,7 @@ mod tests {
         file.flush().unwrap();
     }
 
+    #[cfg(windows)]
     fn proc_info(pid: u32, ppid: u32, command: &str) -> ProcInfo {
         ProcInfo {
             pid,

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -416,15 +416,15 @@ pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     })
 }
 
-/// Windows variant: scans all argv-like tokens, splits on `\`, strips a
+/// Windows variant: checks executable-position tokens, splits on `\`, strips a
 /// trailing `.exe` and common script extensions (`.js`, `.sh`, `.py`), and
 /// matches case-insensitively.
 /// Kept separate from the unix impl so non-Windows matching stays exact
 /// (`Claude` must not match `claude` on linux/macOS).
 #[cfg(windows)]
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
-    cmd.split_whitespace().any(|tok| {
-        let tok = tok.trim_matches('"');
+    windows_command_tokens(cmd).into_iter().take(2).any(|tok| {
+        let tok = tok.as_str();
         let mut iter = tok.rsplit(['/', '\\']);
         let base = iter.next().unwrap_or(tok);
         let base = base
@@ -442,6 +442,31 @@ pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
                 if versions.eq_ignore_ascii_case("versions") && parent.eq_ignore_ascii_case(name)
         )
     })
+}
+
+#[cfg(windows)]
+fn windows_command_tokens(cmd: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in cmd.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            c if c.is_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            c => current.push(c),
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
 }
 
 pub fn collect_git_stats(cwd: &str) -> (u32, u32) {
@@ -515,6 +540,15 @@ mod tests {
     fn cmd_has_binary_windows_detects_node_wrapped_codex() {
         assert!(cmd_has_binary(
             r#""C:\Program Files\nodejs\node.exe" C:\Users\GK\AppData\Roaming\npm\node_modules\@openai\codex\bin\codex.js -m gpt-5.5"#,
+            "codex",
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cmd_has_binary_windows_ignores_codex_in_later_args() {
+        assert!(!cmd_has_binary(
+            r#""C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile "C:\Users\GK\AppData\Roaming\npm\node_modules\@openai\codex\bin\codex.js""#,
             "codex",
         ));
     }

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -416,14 +416,15 @@ pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     })
 }
 
-/// Windows variant: also splits on `\`, strips a trailing `.exe` and common
-/// script extensions (`.js`, `.sh`, `.py`), and matches case-insensitively.
+/// Windows variant: scans all argv-like tokens, splits on `\`, strips a
+/// trailing `.exe` and common script extensions (`.js`, `.sh`, `.py`), and
+/// matches case-insensitively.
 /// Kept separate from the unix impl so non-Windows matching stays exact
 /// (`Claude` must not match `claude` on linux/macOS).
 #[cfg(windows)]
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
-    let mut tokens = cmd.split_whitespace().take(2);
-    tokens.any(|tok| {
+    cmd.split_whitespace().any(|tok| {
+        let tok = tok.trim_matches('"');
         let mut iter = tok.rsplit(['/', '\\']);
         let base = iter.next().unwrap_or(tok);
         let base = base
@@ -507,6 +508,15 @@ mod tests {
         ));
         // A `versions/` dir not under `<name>/` shouldn't match either.
         assert!(!cmd_has_binary("/some/versions/2.1.121", "claude"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cmd_has_binary_windows_detects_node_wrapped_codex() {
+        assert!(cmd_has_binary(
+            r#""C:\Program Files\nodejs\node.exe" C:\Users\GK\AppData\Roaming\npm\node_modules\@openai\codex\bin\codex.js -m gpt-5.5"#,
+            "codex",
+        ));
     }
 
     fn proc(pid: u32, ppid: u32) -> ProcInfo {

--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -132,7 +132,7 @@ pub fn get_process_info() -> HashMap<u32, ProcInfo> {
         sysinfo::ProcessRefreshKind::new()
             .with_cpu()
             .with_memory()
-            .with_cmd(sysinfo::UpdateKind::OnlyIfNotSet),
+            .with_cmd(sysinfo::UpdateKind::Always),
     );
 
     let mut map = HashMap::new();
@@ -406,14 +406,24 @@ pub fn last_path_segment(s: &str) -> Option<&str> {
 #[cfg(not(windows))]
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
     let mut tokens = cmd.split_whitespace().take(2);
-    tokens.any(|tok| {
-        let mut iter = tok.rsplit('/');
-        let base = iter.next().unwrap_or(tok);
-        if base == name {
-            return true;
-        }
-        matches!((iter.next(), iter.next()), (Some("versions"), Some(parent)) if parent == name)
-    })
+    tokens.any(|tok| unix_token_has_binary(tok, name))
+}
+
+#[cfg(not(windows))]
+pub fn cmd_first_token_has_binary(cmd: &str, name: &str) -> bool {
+    cmd.split_whitespace()
+        .next()
+        .is_some_and(|tok| unix_token_has_binary(tok, name))
+}
+
+#[cfg(not(windows))]
+fn unix_token_has_binary(tok: &str, name: &str) -> bool {
+    let mut iter = tok.rsplit('/');
+    let base = iter.next().unwrap_or(tok);
+    if base == name {
+        return true;
+    }
+    matches!((iter.next(), iter.next()), (Some("versions"), Some(parent)) if parent == name)
 }
 
 /// Windows variant: checks executable-position tokens, splits on `\`, strips a
@@ -423,25 +433,37 @@ pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
 /// (`Claude` must not match `claude` on linux/macOS).
 #[cfg(windows)]
 pub fn cmd_has_binary(cmd: &str, name: &str) -> bool {
-    windows_command_tokens(cmd).into_iter().take(2).any(|tok| {
-        let tok = tok.as_str();
-        let mut iter = tok.rsplit(['/', '\\']);
-        let base = iter.next().unwrap_or(tok);
-        let base = base
-            .strip_suffix(".exe")
-            .or_else(|| base.strip_suffix(".js"))
-            .or_else(|| base.strip_suffix(".sh"))
-            .or_else(|| base.strip_suffix(".py"))
-            .unwrap_or(base);
-        if base.eq_ignore_ascii_case(name) {
-            return true;
-        }
-        matches!(
-            (iter.next(), iter.next()),
-            (Some(versions), Some(parent))
-                if versions.eq_ignore_ascii_case("versions") && parent.eq_ignore_ascii_case(name)
-        )
-    })
+    windows_command_tokens(cmd)
+        .into_iter()
+        .take(2)
+        .any(|tok| windows_token_has_binary(&tok, name))
+}
+
+#[cfg(windows)]
+pub fn cmd_first_token_has_binary(cmd: &str, name: &str) -> bool {
+    windows_command_tokens(cmd)
+        .first()
+        .is_some_and(|tok| windows_token_has_binary(tok, name))
+}
+
+#[cfg(windows)]
+fn windows_token_has_binary(tok: &str, name: &str) -> bool {
+    let mut iter = tok.rsplit(['/', '\\']);
+    let base = iter.next().unwrap_or(tok);
+    let base = base
+        .strip_suffix(".exe")
+        .or_else(|| base.strip_suffix(".js"))
+        .or_else(|| base.strip_suffix(".sh"))
+        .or_else(|| base.strip_suffix(".py"))
+        .unwrap_or(base);
+    if base.eq_ignore_ascii_case(name) {
+        return true;
+    }
+    matches!(
+        (iter.next(), iter.next()),
+        (Some(versions), Some(parent))
+            if versions.eq_ignore_ascii_case("versions") && parent.eq_ignore_ascii_case(name)
+    )
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Summary
- scan all Windows command tokens when matching agent binaries
- trim surrounding quotes before path basename checks
- add a regression test for node-wrapped Codex installed under Program Files

## Tests
- cargo test cmd_has_binary -- --nocapture
- cargo test collector::codex -- --nocapture