### PR TITLE
fix(context): read settings.json to detect 1M model before 200k token threshold

### DIFF
--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -527,7 +527,8 @@ impl ClaudeCollector {
             }
         };
 
-        let context_window = context_window_for_model(&model, max_context_tokens);
+        let configured_model = read_configured_model(&sf.cwd);
+        let context_window = context_window_for_model(&model, &configured_model, max_context_tokens);
         let context_percent = if context_window > 0 {
             (last_context_tokens as f64 / context_window as f64) * 100.0
         } else {
@@ -1679,8 +1680,8 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-fn context_window_for_model(model: &str, last_context_tokens: u64) -> u64 {
-    if model.contains("[1m]") || last_context_tokens > 200_000 {
+fn context_window_for_model(transcript_model: &str, configured_model: &str, max_context_tokens: u64) -> u64 {
+    if transcript_model.contains("[1m]") || configured_model.contains("[1m]") || max_context_tokens > 200_000 {
         1_000_000
     } else {
         200_000
@@ -1732,6 +1733,34 @@ fn read_effort_from_settings(path: &Path) -> Option<String> {
         None
     } else {
         Some(level.to_string())
+    }
+}
+
+fn read_configured_model(cwd: &str) -> String {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let cwd_path = PathBuf::from(cwd);
+    candidates.push(cwd_path.join(".claude").join("settings.local.json"));
+    candidates.push(cwd_path.join(".claude").join("settings.json"));
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".claude").join("settings.local.json"));
+        candidates.push(home.join(".claude").join("settings.json"));
+    }
+    for path in candidates {
+        if let Some(model) = read_model_from_settings(&path) {
+            return model;
+        }
+    }
+    String::new()
+}
+
+fn read_model_from_settings(path: &Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    let val: Value = serde_json::from_str(&content).ok()?;
+    let model = val.get("model")?.as_str()?.trim();
+    if model.is_empty() {
+        None
+    } else {
+        Some(model.to_string())
     }
 }
 
@@ -2623,20 +2652,25 @@ n/Users/bob/.claude-alt/projects/-Users-bob-project/session.jsonl
     #[test]
     fn test_context_window_for_model() {
         // Base model with low token usage → 200K
-        assert_eq!(context_window_for_model("claude-opus-4-6", 50_000), 200_000);
-        // Explicit [1m] suffix → 1M regardless of token count
+        assert_eq!(context_window_for_model("claude-opus-4-6", "", 50_000), 200_000);
+        // Explicit [1m] suffix in transcript model → 1M regardless of token count
         assert_eq!(
-            context_window_for_model("claude-opus-4-6[1m]", 0),
+            context_window_for_model("claude-opus-4-6[1m]", "", 0),
+            1_000_000
+        );
+        // [1m] in configured model (from settings.json) → 1M even if transcript lacks it
+        assert_eq!(
+            context_window_for_model("claude-sonnet-4-6", "sonnet[1m]", 0),
             1_000_000
         );
         assert_eq!(
-            context_window_for_model("claude-sonnet-4-6", 100_000),
+            context_window_for_model("claude-sonnet-4-6", "", 100_000),
             200_000
         );
-        assert_eq!(context_window_for_model("unknown-model", 0), 200_000);
+        assert_eq!(context_window_for_model("unknown-model", "", 0), 200_000);
         // Token usage exceeds 200K → must be 1M window
         assert_eq!(
-            context_window_for_model("claude-opus-4-6", 250_000),
+            context_window_for_model("claude-opus-4-6", "", 250_000),
             1_000_000
         );
     }

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -1688,6 +1688,24 @@ fn context_window_for_model(transcript_model: &str, configured_model: &str, max_
     }
 }
 
+/// Returns the ordered list of Claude Code settings files to check, from
+/// highest to lowest priority, matching Claude Code's own resolution order:
+/// 1. `{cwd}/.claude/settings.local.json`
+/// 2. `{cwd}/.claude/settings.json`
+/// 3. `~/.claude/settings.local.json`
+/// 4. `~/.claude/settings.json`
+fn settings_candidate_paths(cwd: &str) -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let cwd_path = PathBuf::from(cwd);
+    candidates.push(cwd_path.join(".claude").join("settings.local.json"));
+    candidates.push(cwd_path.join(".claude").join("settings.json"));
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".claude").join("settings.local.json"));
+        candidates.push(home.join(".claude").join("settings.json"));
+    }
+    candidates
+}
+
 /// Read the persistent `effortLevel` for a Claude Code session.
 ///
 /// Precedence (highest wins), matching Claude Code's own resolution order:
@@ -1708,16 +1726,7 @@ fn read_effort_level(cwd: &str) -> String {
         }
     }
 
-    let mut candidates: Vec<PathBuf> = Vec::new();
-    let cwd_path = PathBuf::from(cwd);
-    candidates.push(cwd_path.join(".claude").join("settings.local.json"));
-    candidates.push(cwd_path.join(".claude").join("settings.json"));
-    if let Some(home) = dirs::home_dir() {
-        candidates.push(home.join(".claude").join("settings.local.json"));
-        candidates.push(home.join(".claude").join("settings.json"));
-    }
-
-    for path in candidates {
+    for path in settings_candidate_paths(cwd) {
         if let Some(level) = read_effort_from_settings(&path) {
             return level;
         }
@@ -1736,16 +1745,27 @@ fn read_effort_from_settings(path: &Path) -> Option<String> {
     }
 }
 
+/// Read the configured model from Claude Code's settings files.
+///
+/// Precedence (highest wins), matching Claude Code's own resolution order:
+/// 1. `CLAUDE_CODE_MODEL` env var (abtop's own env — only visible when
+///    set in the user's shell before launching both abtop and claude)
+/// 2. `{cwd}/.claude/settings.local.json`
+/// 3. `{cwd}/.claude/settings.json`
+/// 4. `~/.claude/settings.local.json`
+/// 5. `~/.claude/settings.json`
+///
+/// Returns an empty string when no model is configured. The value may include
+/// the `[1m]` suffix (e.g. `"sonnet[1m]"`) which is used to detect 1M context.
 fn read_configured_model(cwd: &str) -> String {
-    let mut candidates: Vec<PathBuf> = Vec::new();
-    let cwd_path = PathBuf::from(cwd);
-    candidates.push(cwd_path.join(".claude").join("settings.local.json"));
-    candidates.push(cwd_path.join(".claude").join("settings.json"));
-    if let Some(home) = dirs::home_dir() {
-        candidates.push(home.join(".claude").join("settings.local.json"));
-        candidates.push(home.join(".claude").join("settings.json"));
+    if let Ok(v) = std::env::var("CLAUDE_CODE_MODEL") {
+        let trimmed = v.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
     }
-    for path in candidates {
+
+    for path in settings_candidate_paths(cwd) {
         if let Some(model) = read_model_from_settings(&path) {
             return model;
         }

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -376,7 +376,7 @@ impl CodexCollector {
             }
 
             // Sort by modification time descending (most recent first)
-            candidates.sort_by(|a, b| b.1.cmp(&a.1));
+            candidates.sort_by_key(|b| std::cmp::Reverse(b.1));
 
             // Assign candidates to PIDs (most recent file → first PID)
             for (i, &pid_u32) in pids.iter().enumerate() {


### PR DESCRIPTION
## Summary

Fixes #109

- Claude Code stores only the bare API model name (e.g. `claude-sonnet-4-6`) in JSONL transcripts — the `[1m]` suffix never appears there, so the existing `model.contains("[1m]")` check in `context_window_for_model` never matched.
- The only fallback was `max_context_tokens > 200_000`, which means the 1M window size was not recognised until 200k tokens had already been consumed, making the context percentage read ~5× too high throughout the early phase of every 1M session.

## Fix

Add `read_configured_model` (follows the same settings-file priority chain as the existing `read_effort_level`) to read the `model` key from Claude Code's `settings.json`. That key **does** contain the `[1m]` suffix (e.g. `"sonnet[1m]"`).

`context_window_for_model` now accepts a `configured_model` parameter and returns 1 M if **either** the transcript model or the configured model contains `[1m]`, so the correct window size is used from the very first turn.

## Changes

- `src/collector/claude.rs`
  - `context_window_for_model(transcript_model, configured_model, max_context_tokens)` — new signature
  - `read_configured_model(cwd)` + `read_model_from_settings(path)` — new helpers
  - Updated call site and existing unit tests; added a test for settings-based detection

## Test plan

- [x] `cargo test` passes (updated `test_context_window_for_model` covers the new `configured_model` path)
- [ ] Start abtop with a `claude-sonnet-4-6[1m]` session that has < 200k tokens — Context % should now reflect the 1M window