### PR TITLE
fix(unix): detect claude.exe binary on macOS/Linux

### DIFF
--- a/src/collector/process.rs
+++ b/src/collector/process.rs
@@ -423,6 +423,12 @@ fn unix_token_has_binary(tok: &str, name: &str) -> bool {
     if base == name {
         return true;
     }
+    // Strip .exe suffix for compatibility with claude.exe on non-Windows (e.g. @anthropic-ai/claude-code npm package)
+    if let Some(stripped) = base.strip_suffix(".exe") {
+        if stripped == name {
+            return true;
+        }
+    }
     matches!((iter.next(), iter.next()), (Some("versions"), Some(parent)) if parent == name)
 }
 
@@ -533,6 +539,20 @@ mod tests {
         assert!(cmd_has_binary("/usr/local/bin/claude --foo", "claude"));
         assert!(cmd_has_binary("claude", "claude"));
         assert!(!cmd_has_binary("/usr/local/bin/claude-launch", "claude"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn cmd_has_binary_exe_suffix_on_unix() {
+        // The @anthropic-ai/claude-code npm package ships a binary named
+        // `claude.exe` even on macOS/Linux. Ensure we still detect it.
+        assert!(cmd_has_binary(
+            "/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe --session-id abc",
+            "claude",
+        ));
+        assert!(cmd_has_binary("claude.exe", "claude"));
+        // Must not match unrelated .exe binaries
+        assert!(!cmd_has_binary("/usr/bin/notclaude.exe", "claude"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `@anthropic-ai/claude-code` npm package ships its binary as `claude.exe` even on non-Windows platforms. The existing `unix_token_has_binary` only compared the exact basename, so processes running as:

```
/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe --session-id ...
```

were completely invisible to abtop — `find_claude_pids` returned an empty list, and no sessions were ever displayed.

This PR strips the `.exe` suffix before comparing on Unix, mirroring the behavior already present in the Windows code path.

## Changes

- `src/collector/process.rs`: add `.exe` suffix stripping in `unix_token_has_binary()`
- Added test `cmd_has_binary_exe_suffix_on_unix` covering the new behavior

## Test plan

- [x] `cargo test cmd_has_binary` — all 4 tests pass
- [x] Manually verified on macOS with `claude.exe` process — abtop now shows sessions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)