### PR TITLE
feat: show session chat history

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -898,6 +898,7 @@ mod tests {
             children: vec![],
             initial_prompt: String::new(),
             first_assistant_text: String::new(),
+            chat_messages: vec![],
             tool_calls: vec![],
             pending_since_ms: 0,
             thinking_since_ms: 0,

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -1,7 +1,7 @@
 use super::process::{self, ProcInfo};
 use crate::model::{
-    AgentSession, ChildProcess, FileAccess, FileOp, SessionFile, SessionStatus, SubAgent,
-    MAX_FILE_ACCESSES,
+    AgentSession, ChatMessage, ChatRole, ChildProcess, FileAccess, FileOp, SessionFile,
+    SessionStatus, SubAgent, MAX_CHAT_MESSAGES, MAX_FILE_ACCESSES,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -106,7 +106,8 @@ impl ClaudeCollector {
         }
 
         let self_pid = std::process::id();
-        let active_session_paths = self.discover_active_session_paths(&shared.process_info, self_pid);
+        let active_session_paths =
+            self.discover_active_session_paths(&shared.process_info, self_pid);
         let active_config_dirs: Vec<ConfigDir> = active_session_paths
             .iter()
             .map(|(_, config)| config.clone())
@@ -408,6 +409,11 @@ impl ClaudeCollector {
                         prev.tool_calls
                             .extend(delta.tool_calls.into_iter().take(remaining));
                     }
+                    prev.chat_messages.extend(delta.chat_messages);
+                    let len = prev.chat_messages.len();
+                    if len > MAX_CHAT_MESSAGES {
+                        prev.chat_messages.drain(..len - MAX_CHAT_MESSAGES);
+                    }
                     // Only overwrite turn-state when the delta actually
                     // observed new user/assistant lines. A no-op tick (file
                     // didn't grow) returns an empty delta whose zeroed
@@ -458,6 +464,7 @@ impl ClaudeCollector {
             token_history: Vec::new(),
             initial_prompt: String::new(),
             first_assistant_text: String::new(),
+            chat_messages: Vec::new(),
             tool_calls: Vec::new(),
             last_assistant_ts_ms: 0,
             last_user_ts_ms: 0,
@@ -485,6 +492,7 @@ impl ClaudeCollector {
         let compaction_count = cached.compaction_count;
         let initial_prompt = cached.initial_prompt.clone();
         let first_assistant_text = cached.first_assistant_text.clone();
+        let chat_messages = cached.chat_messages.clone();
         let tool_calls = cached.tool_calls.clone();
         let file_accesses = cached.file_accesses.clone();
 
@@ -624,6 +632,7 @@ impl ClaudeCollector {
             children,
             initial_prompt,
             first_assistant_text,
+            chat_messages,
             tool_calls,
             pending_since_ms: cached.last_assistant_ts_ms,
             thinking_since_ms: cached.last_user_ts_ms,
@@ -1157,6 +1166,8 @@ struct TranscriptResult {
     initial_prompt: String,
     /// First assistant response text (text blocks only, no tool_use)
     first_assistant_text: String,
+    /// Recent real chat messages, excluding tool_result wrappers and tool inputs.
+    chat_messages: Vec<ChatMessage>,
     /// Tool call timeline extracted from transcript.
     tool_calls: Vec<crate::model::ToolCall>,
     /// Timestamp of the last assistant turn (epoch ms), used to compute tool duration.
@@ -1239,6 +1250,7 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
         token_history: Vec::new(),
         initial_prompt: String::new(),
         first_assistant_text: String::new(),
+        chat_messages: Vec::new(),
         tool_calls: Vec::new(),
         last_assistant_ts_ms: 0,
         last_user_ts_ms: 0,
@@ -1420,6 +1432,14 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
                                         }
                                     }
                                 }
+                                let assistant_text = extract_chat_text(msg);
+                                if !assistant_text.is_empty() {
+                                    push_chat_message(
+                                        &mut result.chat_messages,
+                                        ChatRole::Assistant,
+                                        assistant_text,
+                                    );
+                                }
                                 // Extract all tool_use entries: timeline + current_task + file access audit
                                 let mut has_tool_use = false;
                                 if let Some(content) = msg.get("content").and_then(|c| c.as_array())
@@ -1480,6 +1500,7 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
                             }
                         }
                         Some("user") => {
+                            let is_tool_result = is_tool_result_user_msg(val.get("message"));
                             // Compute tool call duration: time from assistant turn to this user turn
                             if entry_ts_ms > 0 && result.last_assistant_ts_ms > 0 {
                                 let duration =
@@ -1511,7 +1532,7 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
                             // inside one logical turn, and treating each
                             // tool_result as the start of a new thinking window
                             // makes the status flicker Think ↔ Wait per tool call.
-                            if entry_ts_ms > 0 && !is_tool_result_user_msg(val.get("message")) {
+                            if entry_ts_ms > 0 && !is_tool_result {
                                 result.last_user_ts_ms = entry_ts_ms;
                             }
                             result.saw_turn = true;
@@ -1525,6 +1546,18 @@ fn parse_transcript(path: &Path, from_offset: u64) -> TranscriptResult {
                             if result.initial_prompt.is_empty() {
                                 if let Some(msg) = val.get("message") {
                                     result.initial_prompt = extract_prompt_text(msg);
+                                }
+                            }
+                            if !is_tool_result {
+                                if let Some(msg) = val.get("message") {
+                                    let user_text = extract_chat_text(msg);
+                                    if !user_text.is_empty() {
+                                        push_chat_message(
+                                            &mut result.chat_messages,
+                                            ChatRole::User,
+                                            user_text,
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -1571,6 +1604,65 @@ fn is_tool_result_user_msg(message: Option<&Value>) -> bool {
     }
     arr.iter()
         .all(|block| block.get("type").and_then(|t| t.as_str()) == Some("tool_result"))
+}
+
+fn push_chat_message(messages: &mut Vec<ChatMessage>, role: ChatRole, text: String) {
+    if text.is_empty() {
+        return;
+    }
+    messages.push(ChatMessage { role, text });
+    let len = messages.len();
+    if len > MAX_CHAT_MESSAGES {
+        messages.drain(..len - MAX_CHAT_MESSAGES);
+    }
+}
+
+fn extract_chat_text(message: &Value) -> String {
+    let raw = match message.get("content") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|block| {
+                if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                    block
+                        .get("text")
+                        .and_then(|t| t.as_str())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => String::new(),
+    };
+    clean_chat_text(&raw, 500)
+}
+
+fn clean_chat_text(raw: &str, max: usize) -> String {
+    let cleaned = raw
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty() && !l.starts_with("```"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let mut without_images = cleaned;
+    while let Some(start) = without_images.find("[Image") {
+        if let Some(end) = without_images[start..].find(']') {
+            without_images = format!(
+                "{}{}",
+                &without_images[..start],
+                without_images[start + end + 1..].trim_start()
+            );
+        } else {
+            break;
+        }
+    }
+
+    let terminal_safe = super::sanitize_terminal_text(without_images.trim());
+    let redacted = super::redact_secrets(&terminal_safe);
+    truncate(&redacted, max)
 }
 
 fn encode_cwd_path(cwd: &str) -> String {
@@ -2560,6 +2652,31 @@ n/Users/bob/.claude-alt/projects/-Users-bob-project/session.jsonl
         assert_eq!(result.total_input, 300); // 100 + 200
         assert_eq!(result.total_output, 130); // 50 + 80
         assert_eq!(result.token_history.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_transcript_chat_tail_skips_tool_results() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write_lines(
+            &mut file,
+            &[
+                r#"{"type":"user","timestamp":"2026-03-28T15:00:00Z","message":{"role":"user","content":"fi\u0007x login\u202E"}}"#,
+                r#"{"type":"assistant","timestamp":"2026-03-28T15:00:05Z","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":1,"output_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"text","text":"I'll inspect\u0008 auth."},{"type":"tool_use","name":"Read","input":{"file_path":"src/auth.rs"}}]}}"#,
+                r#"{"type":"user","timestamp":"2026-03-28T15:00:06Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"secret output"}]}}"#,
+                r#"{"type":"assistant","timestamp":"2026-03-28T15:00:10Z","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":1,"output_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"text","text":"Root cause is the guard."}]}}"#,
+            ],
+        );
+        let result = parse_transcript(file.path(), 0);
+        assert_eq!(result.chat_messages.len(), 3);
+        assert_eq!(result.chat_messages[0].role, ChatRole::User);
+        assert_eq!(result.chat_messages[0].text, "fix login");
+        assert_eq!(result.chat_messages[1].role, ChatRole::Assistant);
+        assert_eq!(result.chat_messages[1].text, "I'll inspect auth.");
+        assert_eq!(result.chat_messages[2].text, "Root cause is the guard.");
+        assert!(result
+            .chat_messages
+            .iter()
+            .all(|msg| !msg.text.contains("secret output")));
     }
 
     #[test]

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -1,5 +1,8 @@
 use super::process::{self, ProcInfo};
-use crate::model::{AgentSession, ChildProcess, RateLimitInfo, SessionStatus, ToolCall};
+use crate::model::{
+    AgentSession, ChatMessage, ChatRole, ChildProcess, RateLimitInfo, SessionStatus, ToolCall,
+    MAX_CHAT_MESSAGES,
+};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
@@ -47,10 +50,8 @@ impl CodexCollector {
         // Step 1: Find running codex processes from shared ps data (no extra ps call).
         // When MCP suppression is on, exclude `codex mcp-server` PIDs — those
         // are surfaced through the MCP servers panel instead. See issue #95.
-        let codex_pids = Self::find_codex_pids_from_shared(
-            &shared.process_info,
-            &shared.mcp_server_pids,
-        );
+        let codex_pids =
+            Self::find_codex_pids_from_shared(&shared.process_info, &shared.mcp_server_pids);
         let just_pids: Vec<u32> = codex_pids.iter().map(|(p, _)| *p).collect();
         let pid_to_jsonl = Self::map_pid_to_jsonl(&just_pids, &self.sessions_dir);
         let pid_is_exec: HashMap<u32, bool> = codex_pids.into_iter().collect();
@@ -176,7 +177,9 @@ impl CodexCollector {
         let mem_mb = proc.map(|p| p.rss_kb / 1024).unwrap_or(0);
         let display_pid = pid.unwrap_or(0);
 
-        let project_name = process::last_path_segment(&result.cwd).unwrap_or("?").to_string();
+        let project_name = process::last_path_segment(&result.cwd)
+            .unwrap_or("?")
+            .to_string();
 
         // Status detection
         // Note: Codex interactive sessions emit task_complete after every turn,
@@ -283,6 +286,7 @@ impl CodexCollector {
                 children,
                 initial_prompt: result.initial_prompt,
                 first_assistant_text: String::new(),
+                chat_messages: result.chat_messages,
                 tool_calls: result.tool_calls,
                 pending_since_ms: result.pending_since_ms,
                 thinking_since_ms: result.thinking_since_ms,
@@ -471,6 +475,7 @@ struct CodexJSONLResult {
     model_generating: bool,
     last_activity: std::time::SystemTime,
     initial_prompt: String,
+    chat_messages: Vec<ChatMessage>,
     total_input: u64,
     total_output: u64,
     total_cache_read: u64,
@@ -516,6 +521,29 @@ fn value_to_tool_arg(value: &Value) -> Option<String> {
 fn sanitize_tool_arg(arg: &str) -> String {
     let redacted = super::redact_secrets(arg);
     redacted.chars().take(120).collect()
+}
+
+fn push_chat_message(messages: &mut Vec<ChatMessage>, role: ChatRole, text: String) {
+    if text.is_empty() {
+        return;
+    }
+    messages.push(ChatMessage { role, text });
+    let len = messages.len();
+    if len > MAX_CHAT_MESSAGES {
+        messages.drain(..len - MAX_CHAT_MESSAGES);
+    }
+}
+
+fn clean_chat_text(raw: &str, max: usize) -> String {
+    let cleaned = raw
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty() && !l.starts_with("```"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let terminal_safe = super::sanitize_terminal_text(&cleaned);
+    let redacted = super::redact_secrets(&terminal_safe);
+    redacted.chars().take(max).collect()
 }
 
 fn parse_codex_tool_arg(arguments: &str) -> String {
@@ -626,6 +654,7 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
         model_generating: false,
         last_activity: std::time::UNIX_EPOCH,
         initial_prompt: String::new(),
+        chat_messages: Vec::new(),
         total_input: 0,
         total_output: 0,
         total_cache_read: 0,
@@ -718,11 +747,16 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                     Some("user_message") => {
                         result.model_generating = true;
                         result.thinking_since_ms = event_timestamp_ms(&val).unwrap_or(0);
-                        if result.initial_prompt.is_empty() {
-                            if let Some(msg) = payload["message"].as_str() {
+                        if let Some(msg) = payload["message"].as_str() {
+                            if result.initial_prompt.is_empty() {
                                 let truncated: String = msg.chars().take(120).collect();
                                 result.initial_prompt = super::redact_secrets(&truncated);
                             }
+                            push_chat_message(
+                                &mut result.chat_messages,
+                                ChatRole::User,
+                                clean_chat_text(msg, 500),
+                            );
                         }
                     }
                     Some("token_count") => {
@@ -795,6 +829,13 @@ fn parse_codex_jsonl(path: &Path) -> Option<CodexJSONLResult> {
                         result.turn_count += 1;
                         result.model_generating = false;
                         result.thinking_since_ms = 0;
+                        if let Some(msg) = payload["message"].as_str() {
+                            push_chat_message(
+                                &mut result.chat_messages,
+                                ChatRole::Assistant,
+                                clean_chat_text(msg, 500),
+                            );
+                        }
                     }
                     Some("task_complete") => {
                         result.task_complete = true;
@@ -1137,6 +1178,28 @@ mod tests {
         assert!(
             !result.model_generating,
             "agent_message must close the thinking window"
+        );
+    }
+
+    #[test]
+    fn test_parse_codex_chat_tail_from_user_and_agent_messages() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write_lines(
+            &mut file,
+            &[
+                SESSION_META,
+                r#"{"type":"event_msg","timestamp":"2026-03-28T15:01:00Z","payload":{"type":"user_message","message":"check \u0007auth\u202E sk-proj-secret"}}"#,
+                r#"{"type":"event_msg","timestamp":"2026-03-28T15:02:00Z","payload":{"type":"agent_message","message":"Auth guard\u0008 is the failing path."}}"#,
+            ],
+        );
+        let result = parse_codex_jsonl(file.path()).unwrap();
+        assert_eq!(result.chat_messages.len(), 2);
+        assert_eq!(result.chat_messages[0].role, ChatRole::User);
+        assert_eq!(result.chat_messages[0].text, "check auth [REDACTED]");
+        assert_eq!(result.chat_messages[1].role, ChatRole::Assistant);
+        assert_eq!(
+            result.chat_messages[1].text,
+            "Auth guard is the failing path."
         );
     }
 

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -58,6 +58,20 @@ pub(crate) fn redact_secrets(s: &str) -> String {
     result
 }
 
+/// Strip control characters and Unicode bidi override/isolate marks before
+/// transcript text is stored for terminal rendering.
+pub(crate) fn sanitize_terminal_text(s: &str) -> String {
+    s.chars()
+        .filter(|c| {
+            !c.is_control()
+                && !matches!(
+                    *c,
+                    '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' | '\u{200E}' | '\u{200F}'
+                )
+        })
+        .collect()
+}
+
 use crate::model::{AgentSession, OrphanPort, RateLimitInfo, SessionStatus};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -190,6 +190,7 @@ impl OpenCodeCollector {
                 children,
                 initial_prompt: ds.title.clone(),
                 first_assistant_text: String::new(),
+                chat_messages: vec![],
                 tool_calls: vec![],
                 pending_since_ms: 0,
                 thinking_since_ms: 0,

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1,7 +1,7 @@
 use crate::app::App;
 use crate::model::{
-    AgentSession, ChildProcess, FileAccess, FileOp, OrphanPort, RateLimitInfo, SessionStatus,
-    SubAgent, ToolCall,
+    AgentSession, ChatMessage, ChatRole, ChildProcess, FileAccess, FileOp, OrphanPort,
+    RateLimitInfo, SessionStatus, SubAgent, ToolCall,
 };
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -89,6 +89,24 @@ pub fn populate_demo(app: &mut App) {
             ],
 
             first_assistant_text: String::new(),
+            chat_messages: vec![
+                ChatMessage {
+                    role: ChatRole::User,
+                    text: "Implement Stripe payment integration for checkout flow".into(),
+                },
+                ChatMessage {
+                    role: ChatRole::Assistant,
+                    text: "I'll inspect checkout and config paths first, then wire the smallest payment boundary.".into(),
+                },
+                ChatMessage {
+                    role: ChatRole::User,
+                    text: "Keep webhook handling minimal and make tests cover declined cards.".into(),
+                },
+                ChatMessage {
+                    role: ChatRole::Assistant,
+                    text: "Payment code is in place; current pass is tightening test failures around webhook signatures.".into(),
+                },
+            ],
             initial_prompt: "Implement Stripe payment integration for checkout flow".into(),
             tool_calls: vec![
                 ToolCall {
@@ -273,6 +291,16 @@ pub fn populate_demo(app: &mut App) {
             children: vec![],
 
             first_assistant_text: String::new(),
+            chat_messages: vec![
+                ChatMessage {
+                    role: ChatRole::User,
+                    text: "Add batch inference endpoint with GPU scheduling".into(),
+                },
+                ChatMessage {
+                    role: ChatRole::Assistant,
+                    text: "Endpoint is implemented; waiting on your choice for queue priority behavior.".into(),
+                },
+            ],
             initial_prompt: "Add batch inference endpoint with GPU scheduling".into(),
             tool_calls: vec![],
             pending_since_ms: 0,
@@ -332,6 +360,16 @@ pub fn populate_demo(app: &mut App) {
             ],
 
             first_assistant_text: String::new(),
+            chat_messages: vec![
+                ChatMessage {
+                    role: ChatRole::User,
+                    text: "Fix CORS headers and add rate limiting middleware".into(),
+                },
+                ChatMessage {
+                    role: ChatRole::Assistant,
+                    text: "I'll patch middleware order, then run the API smoke tests.".into(),
+                },
+            ],
             initial_prompt: "Fix CORS headers and add rate limiting middleware".into(),
             tool_calls: vec![
                 ToolCall {
@@ -409,6 +447,16 @@ pub fn populate_demo(app: &mut App) {
             }],
 
             first_assistant_text: String::new(),
+            chat_messages: vec![
+                ChatMessage {
+                    role: ChatRole::User,
+                    text: "Create interactive heatmap component with D3.js".into(),
+                },
+                ChatMessage {
+                    role: ChatRole::Assistant,
+                    text: "Building the component now; next check is responsive canvas sizing.".into(),
+                },
+            ],
             initial_prompt: "Create interactive heatmap component with D3.js".into(),
             tool_calls: vec![],
             pending_since_ms: 0,
@@ -449,6 +497,7 @@ pub fn populate_demo(app: &mut App) {
             children: vec![],
 
             first_assistant_text: String::new(),
+            chat_messages: vec![],
             initial_prompt: "Refactor Terraform modules for multi-region".into(),
             tool_calls: vec![],
             pending_since_ms: 0,

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -92,6 +92,7 @@ static LOCALE_EN: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("detail.turns", "turns");
     m.insert("detail.effort", "effort");
     m.insert("detail.timeline", "TIMELINE");
+    m.insert("detail.chat", "CHAT");
     m.insert("detail.calls", "calls");
     m.insert("detail.running", "running");
     m.insert("detail.thinking", "thinking");
@@ -336,6 +337,7 @@ static LOCALE_ZH: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("detail.turns", "轮");
     m.insert("detail.effort", "投入");
     m.insert("detail.timeline", "时间线");
+    m.insert("detail.chat", "聊天");
     m.insert("detail.calls", "调用");
     m.insert("detail.running", "运行中");
     m.insert("detail.thinking", "思考中");

--- a/src/model/session.rs
+++ b/src/model/session.rs
@@ -105,6 +105,22 @@ pub struct ToolCall {
     pub duration_ms: u64,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChatRole {
+    User,
+    Assistant,
+}
+
+/// A compact, redacted chat line from the session transcript.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChatMessage {
+    pub role: ChatRole,
+    pub text: String,
+}
+
+/// Maximum chat messages kept per session to bound memory and UI noise.
+pub const MAX_CHAT_MESSAGES: usize = 12;
+
 #[derive(Debug, Clone)]
 pub struct AgentSession {
     /// Which CLI tool this session belongs to: "claude", "codex", etc.
@@ -148,6 +164,8 @@ pub struct AgentSession {
     pub initial_prompt: String,
     /// First assistant response text (text blocks only) — used as summary fallback
     pub first_assistant_text: String,
+    /// Recent user/assistant chat tail, excluding tool results and tool inputs.
+    pub chat_messages: Vec<ChatMessage>,
     /// Timeline of tool calls extracted from transcript.
     pub tool_calls: Vec<ToolCall>,
     /// Unix-epoch ms of the assistant turn whose `tool_use` blocks are still
@@ -265,6 +283,7 @@ mod tests {
             children: Vec::new(),
             initial_prompt: String::new(),
             first_assistant_text: String::new(),
+            chat_messages: Vec::new(),
             tool_calls: Vec::new(),
             pending_since_ms: 0,
             thinking_since_ms: 0,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -546,6 +546,9 @@ pub(crate) fn truncate_str(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::PanelVisibility;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
 
     #[test]
     fn fmt_age_buckets() {
@@ -559,5 +562,31 @@ mod tests {
         // Regression: the quota panel used to render this raw as "341493ago"
         // because it formatted seconds without unit conversion.
         assert_eq!(fmt_age(341_493), "3d ago");
+    }
+
+    #[test]
+    fn desktop_default_detail_shows_chat_instead_of_timeline() {
+        let mut app = App::new_with_config(Theme::default(), &[], PanelVisibility::default());
+        crate::demo::populate_demo(&mut app);
+        app.sessions[app.selected].children.clear();
+        app.sessions[app.selected].subagents.clear();
+
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &app)).unwrap();
+        let text = format!("{}", terminal.backend());
+
+        assert!(
+            text.contains("CHAT"),
+            "chat should render by default\n{text}"
+        );
+        assert!(
+            text.contains("webhook signatures"),
+            "recent chat tail should render selected session messages\n{text}"
+        );
+        assert!(
+            !text.contains("TIMELINE"),
+            "timeline should be opt-in via l toggle\n{text}"
+        );
     }
 }

--- a/src/ui/sessions.rs
+++ b/src/ui/sessions.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::locale::t;
-use crate::model::{AgentSession, FileOp};
+use crate::model::{AgentSession, ChatRole, FileOp};
 use crate::theme::Theme;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -458,11 +458,20 @@ pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &
         let has_children = !session.children.is_empty();
         let has_subagents = !session.subagents.is_empty();
         let has_tool_calls = !session.tool_calls.is_empty();
+        let has_chat = !session.chat_messages.is_empty();
+        let has_left_detail = has_children || has_subagents;
         let has_file_audit = app.show_file_audit && !session.file_accesses.is_empty();
         // Focus mode: file audit (F) takes priority over timeline (L) when both
         // are toggled on. Only one "full lower" mode is active at a time.
         let file_audit_focused = has_file_audit;
         let timeline_focused = !file_audit_focused && app.show_timeline && has_tool_calls;
+        // Default detail is chat when available; otherwise retain the existing
+        // compact timeline split.
+        const CHAT_SPLIT_MIN_WIDTH: u16 = 120;
+        let chat_default = !file_audit_focused && !app.show_timeline && has_chat;
+        let chat_side_by_side =
+            chat_default && has_left_detail && detail_body.width >= CHAT_SPLIT_MIN_WIDTH;
+        let chat_full_width = chat_default && !chat_side_by_side;
         // Default split: when neither focus mode is active, show a compact
         // timeline in the right half of the lower area - but only if the
         // terminal is wide enough that both halves remain readable
@@ -470,6 +479,7 @@ pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &
         const TIMELINE_SPLIT_MIN_WIDTH: u16 = 120;
         let timeline_side_by_side = !file_audit_focused
             && !app.show_timeline
+            && !chat_default
             && has_tool_calls
             && detail_body.width >= TIMELINE_SPLIT_MIN_WIDTH;
 
@@ -483,6 +493,8 @@ pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &
         };
         let has_lower = file_audit_focused
             || timeline_focused
+            || chat_full_width
+            || chat_side_by_side
             || timeline_side_by_side
             || has_children
             || has_subagents;
@@ -529,6 +541,7 @@ pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &
         // Layout below the session header:
         //   - file audit focus (F): full-width file audit
         //   - timeline focus (L): full-width timeline
+        //   - default chat: full-width, or split with children/subagents on wide terminals
         //   - wide terminal with tool calls: left = children/subagents, right = compact timeline
         //   - otherwise: children/subagents only (or nothing)
         if let Some(lower) = lower_area {
@@ -536,12 +549,14 @@ pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &
                 draw_file_audit(f, session, lower, theme);
             } else if timeline_focused {
                 draw_timeline(f, session, lower, theme, app.timeline_scroll);
+            } else if chat_full_width {
+                draw_chat_history(f, session, lower, theme);
             } else {
                 // Split 50/50 whenever the side-by-side timeline is active, even if
                 // there's no left content - consistent layout beats saving the empty
                 // half, and sessions that gain/lose children at runtime shouldn't
                 // make the timeline flicker between full- and half-width.
-                let (left_area, right_timeline_area) = if timeline_side_by_side {
+                let (left_area, right_detail_area) = if chat_side_by_side || timeline_side_by_side {
                     let split = Layout::default()
                         .direction(Direction::Horizontal)
                         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
@@ -551,8 +566,12 @@ pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &
                     (lower, None)
                 };
 
-                if let Some(tl_area) = right_timeline_area {
-                    draw_timeline(f, session, tl_area, theme, app.timeline_scroll);
+                if let Some(detail_area) = right_detail_area {
+                    if chat_side_by_side {
+                        draw_chat_history(f, session, detail_area, theme);
+                    } else {
+                        draw_timeline(f, session, detail_area, theme, app.timeline_scroll);
+                    }
                 }
 
                 if has_children || has_subagents {
@@ -784,6 +803,45 @@ pub(crate) fn draw_sessions_panel(f: &mut Frame, app: &App, area: Rect, theme: &
             f.render_widget(Paragraph::new(footer_lines), detail_footer);
         }
     }
+}
+
+/// Render the recent user/assistant chat tail for the selected session.
+fn draw_chat_history(f: &mut Frame, session: &AgentSession, area: Rect, theme: &Theme) {
+    if session.chat_messages.is_empty() {
+        return;
+    }
+
+    let mut lines = Vec::new();
+    lines.push(Line::from(Span::styled(
+        format!(
+            " {} ({})",
+            t("detail.chat").as_str(),
+            session.chat_messages.len()
+        ),
+        Style::default()
+            .fg(theme.title)
+            .add_modifier(Modifier::BOLD),
+    )));
+
+    let visible_rows = area.height.saturating_sub(1) as usize;
+    let start = session.chat_messages.len().saturating_sub(visible_rows);
+    let text_w = (area.width as usize).saturating_sub(6);
+
+    for msg in session.chat_messages.iter().skip(start) {
+        let (label, color) = match msg.role {
+            ChatRole::User => ("U", theme.hi_fg),
+            ChatRole::Assistant => ("A", theme.proc_misc),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {} ", label), Style::default().fg(color)),
+            Span::styled(
+                truncate_str(&msg.text, text_w),
+                Style::default().fg(theme.main_fg),
+            ),
+        ]));
+    }
+
+    f.render_widget(Paragraph::new(lines), area);
 }
 
 /// Render the file access audit log in the given area.


### PR DESCRIPTION
## Summary

Show recent user/assistant chat history for the selected session.

- Collect bounded chat tails from Claude and Codex transcripts
- Exclude tool results and tool inputs
- Sanitize terminal control and bidi characters before rendering
- Keep timeline and file-audit views available behind toggles

## Verification

- `cargo test chat`
- `cargo test`
- `cargo clippy -- -D warnings`