### PR TITLE
fix(opencode): AND lsof selection terms on macOS for cwd lookup

### DIFF
--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -426,8 +426,10 @@ fn get_process_cwd(pid: u32) -> Option<String> {
 
 #[cfg(not(target_os = "linux"))]
 fn get_process_cwd(pid: u32) -> Option<String> {
+    // -a ANDs the selection terms; without it, lsof ORs `-p <pid>` with
+    // `-d cwd` and returns cwd entries for unrelated processes too.
     let output = Command::new("lsof")
-        .args(["-p", &pid.to_string(), "-d", "cwd", "-Fn"])
+        .args(["-a", "-p", &pid.to_string(), "-d", "cwd", "-Fn"])
         .output()
         .ok()?;
     if !output.status.success() {


### PR DESCRIPTION
Credit @Alexander-He for the diagnosis in #120.

Adds `-a` to the lsof call in `get_process_cwd` so `-p <pid>` and `-d cwd` AND instead of OR. Without it, lsof returns cwd entries from unrelated processes too, and the parser grabs the first `n...` line it sees, which can belong to a different pid. The OpenCode session match against the DB `directory` column then fails and the session gets dropped.

Linux path (`/proc/<pid>/cwd`) is unaffected.

Refs #120
