### PR TITLE
fix: discover Claude profile roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Discovery strategy:
 4. Read `{config-root}/sessions/{PID}.json`, falling back to scanning session files for the matching embedded PID
 5. Parse `{config-root}/projects/{encoded-path}/{sessionId}.jsonl`
 
-Fallback config roots are still scanned: `~/.claude`, abtop's own `CLAUDE_CONFIG_DIR`, and on Linux any `CLAUDE_CONFIG_DIR` read from `/proc/{pid}/environ`.
+Fallback config roots are still scanned: `~/.claude`, direct home profile roots matching `~/.claude-*` when they contain both `sessions/` and `projects/`, `claude_config_dirs` from `~/.config/abtop/config.toml`, abtop's own `CLAUDE_CONFIG_DIR`, and on Linux any `CLAUDE_CONFIG_DIR` read from `/proc/{pid}/environ`.
 
 Session file format:
 ```json

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ theme = "btop"
 # Hide specific agent CLIs from the TUI (case-insensitive).
 # Useful if you only use one agent and want a cleaner view.
 hidden_agents = ["codex"]
+# Additional Claude Code profile roots to scan.
+# abtop also auto-discovers ~/.claude and ~/.claude-* roots that contain
+# both sessions/ and projects/.
+claude_config_dirs = ["~/.claude-personal", "~/.claude-work-team"]
 # UI language. Omit or leave empty to auto-detect from LANG.
 language = "zh"
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use crate::host_info::{AgentAggregate, HostMetrics, HostSampler};
 use crate::model::{AgentSession, OrphanPort, RateLimitInfo, SessionStatus};
 use crate::theme::Theme;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
 use std::sync::mpsc;
 use std::time::Instant;
 
@@ -150,14 +151,25 @@ pub struct App {
 }
 
 impl App {
+    #[cfg(test)]
     pub fn new_with_config(
         theme: Theme,
         hidden_agents: &[String],
         panels: crate::config::PanelVisibility,
     ) -> Self {
+        Self::new_with_config_and_claude_dirs(theme, hidden_agents, panels, &[])
+    }
+
+    pub fn new_with_config_and_claude_dirs(
+        theme: Theme,
+        hidden_agents: &[String],
+        panels: crate::config::PanelVisibility,
+        claude_config_dirs: &[PathBuf],
+    ) -> Self {
         let (tx, rx) = mpsc::channel();
         let summaries = load_summary_cache();
-        let mut collector = MultiCollector::with_hidden(hidden_agents);
+        let mut collector =
+            MultiCollector::with_hidden_and_claude_config_dirs(hidden_agents, claude_config_dirs);
         collector.set_mcp_suppress(true);
         Self {
             sessions: Vec::new(),

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -49,22 +49,30 @@ struct ProcessOpenPaths {
 pub struct ClaudeCollector {
     /// All known config directories to scan for sessions.
     config_dirs: Vec<ConfigDir>,
+    /// User-configured Claude config directories from abtop config.
+    configured_config_dirs: Vec<PathBuf>,
     /// Cached transcript parse results keyed by session_id.
     /// On each tick, only new bytes since `new_offset` are parsed.
     transcript_cache: HashMap<String, TranscriptResult>,
 }
 
 impl ClaudeCollector {
+    #[cfg(test)]
     pub fn new() -> Self {
+        Self::with_configured_dirs(Vec::new())
+    }
+
+    pub fn with_configured_dirs(configured_config_dirs: Vec<PathBuf>) -> Self {
         Self {
             config_dirs: Vec::new(),
+            configured_config_dirs,
             transcript_cache: HashMap::new(),
         }
     }
 
-    /// Discover all unique Claude config directories by reading
-    /// /proc/<pid>/environ for each running Claude process.
-    /// Always includes the default (~/.claude) and CLAUDE_CONFIG_DIR if set.
+    /// Discover unique Claude config directories from defaults, configured
+    /// profile roots, home sibling profiles, and process environment/open-file
+    /// signals when the platform exposes them.
     fn refresh_config_dirs(&mut self, process_info: &HashMap<u32, process::ProcInfo>) {
         // BTreeSet for deterministic iteration order across runs.
         let mut seen = std::collections::BTreeSet::new();
@@ -72,6 +80,16 @@ impl ClaudeCollector {
         // Always include the default directory
         let default = dirs::home_dir().unwrap_or_default().join(".claude");
         seen.insert(default);
+
+        if let Some(home) = dirs::home_dir() {
+            seen.extend(discover_home_claude_config_dirs(&home));
+        }
+
+        for dir in &self.configured_config_dirs {
+            if is_claude_config_root(dir) {
+                seen.insert(dir.clone());
+            }
+        }
 
         // Include CLAUDE_CONFIG_DIR from abtop's own environment
         if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
@@ -969,6 +987,27 @@ fn candidate_config_roots_from_path(path: &Path) -> Vec<PathBuf> {
 
 fn is_claude_config_root(path: &Path) -> bool {
     path.join("sessions").is_dir() && path.join("projects").is_dir()
+}
+
+fn discover_home_claude_config_dirs(home: &Path) -> Vec<PathBuf> {
+    let mut roots = std::collections::BTreeSet::new();
+    let Ok(entries) = fs::read_dir(home) else {
+        return Vec::new();
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if name != ".claude" && !name.starts_with(".claude-") {
+            continue;
+        }
+        let path = entry.path();
+        if is_claude_config_root(&path) {
+            roots.insert(path);
+        }
+    }
+
+    roots.into_iter().collect()
 }
 
 /// Per-tick session-discovery state shared across all `load_session` calls
@@ -1966,15 +2005,14 @@ fn read_env_var_from_proc(pid: u32, var_name: &str) -> Option<String> {
 /// Stub for non-Linux platforms where /proc is not available.
 /// Windows has no equivalent way to read another process's environment block
 /// without elevated privileges, so per-process `CLAUDE_CONFIG_DIR` overrides
-/// can't be detected — abtop's own env (resolved in `refresh_config_dirs`)
-/// is the only signal there.
+/// can't be detected. Configured roots, home sibling profile discovery, and
+/// abtop's own env are the portable signals there.
 ///
 /// On macOS, `ps eww`/`KERN_PROCARGS2` are unreliable: the kernel truncates
 /// the env block to ~120 chars for non-root callers, so `CLAUDE_CONFIG_DIR`
-/// is rarely visible. Discovery of profile sessions instead piggybacks on
-/// `libproc` open-FD inspection (see `discover_active_session_paths`), which
-/// reads the actual session-file paths a Claude process has open and infers
-/// the config dir from there.
+/// is rarely visible. Discovery of profile sessions can still use configured
+/// roots, home sibling profiles, and `libproc` open-FD inspection when Claude
+/// exposes session/project paths.
 #[cfg(not(target_os = "linux"))]
 fn read_env_var_from_proc(_pid: u32, _var_name: &str) -> Option<String> {
     None
@@ -2350,6 +2388,44 @@ n/Users/bob/.claude-alt/projects/-Users-bob-project/session.jsonl
 
         assert_eq!(configs.len(), 1);
         assert_eq!(configs[0].base_dir(), profile);
+    }
+
+    #[test]
+    fn test_discover_home_claude_config_dirs_finds_profile_siblings() {
+        let temp = tempfile::tempdir().unwrap();
+        let personal = temp.path().join(".claude-personal");
+        let work = temp.path().join(".claude-work-team");
+        let incomplete = temp.path().join(".claude-cache");
+        std::fs::create_dir_all(personal.join("sessions")).unwrap();
+        std::fs::create_dir_all(personal.join("projects")).unwrap();
+        std::fs::create_dir_all(work.join("sessions")).unwrap();
+        std::fs::create_dir_all(work.join("projects")).unwrap();
+        std::fs::create_dir_all(incomplete.join("sessions")).unwrap();
+
+        let discovered = discover_home_claude_config_dirs(temp.path());
+
+        assert!(discovered.contains(&personal));
+        assert!(discovered.contains(&work));
+        assert!(!discovered.contains(&incomplete));
+    }
+
+    #[test]
+    fn test_refresh_config_dirs_includes_configured_profile_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let profile = temp.path().join(".claude-personal");
+        std::fs::create_dir_all(profile.join("sessions")).unwrap();
+        std::fs::create_dir_all(profile.join("projects")).unwrap();
+
+        let mut collector = ClaudeCollector::with_configured_dirs(vec![profile.clone()]);
+        collector.refresh_config_dirs(&HashMap::new());
+
+        assert!(
+            collector
+                .config_dirs
+                .iter()
+                .any(|config| config.base_dir() == profile),
+            "configured Claude profile root was not retained"
+        );
     }
 
     #[test]

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -177,11 +177,21 @@ impl MultiCollector {
     /// Build a collector, skipping agents whose identifier is in `hidden`.
     /// Identifiers are matched case-insensitively against each collector's
     /// `agent_cli` name (e.g. `"claude"`, `"codex"`).
+    #[cfg(test)]
     pub fn with_hidden(hidden: &[String]) -> Self {
+        Self::with_hidden_and_claude_config_dirs(hidden, &[])
+    }
+
+    pub fn with_hidden_and_claude_config_dirs(
+        hidden: &[String],
+        claude_config_dirs: &[PathBuf],
+    ) -> Self {
         let is_hidden = |name: &str| hidden.iter().any(|h| h.eq_ignore_ascii_case(name));
         let mut collectors: Vec<Box<dyn AgentCollector>> = Vec::new();
         if !is_hidden("claude") {
-            collectors.push(Box::new(ClaudeCollector::new()));
+            collectors.push(Box::new(ClaudeCollector::with_configured_dirs(
+                claude_config_dirs.to_vec(),
+            )));
         }
         if !is_hidden("codex") {
             collectors.push(Box::new(CodexCollector::new()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,9 @@ pub struct AppConfig {
     /// Agent CLI names to exclude from the TUI (e.g. ["codex"] to hide Codex).
     /// Matched case-insensitively against each collector's agent_cli identifier.
     pub hidden_agents: Vec<String>,
+    /// Additional Claude config directories to scan for sessions.
+    /// Useful for multi-profile setups that use separate CLAUDE_CONFIG_DIR roots.
+    pub claude_config_dirs: Vec<PathBuf>,
     pub panels: PanelVisibility,
     /// UI language override. Empty string means auto-detect from `LANG`.
     /// Recognized values: "en", "zh" (anything starting with "zh" maps to Simplified Chinese).
@@ -41,6 +44,7 @@ impl Default for AppConfig {
         Self {
             theme: "btop".to_string(),
             hidden_agents: Vec::new(),
+            claude_config_dirs: Vec::new(),
             panels: PanelVisibility::default(),
             language: String::new(),
         }
@@ -62,6 +66,10 @@ pub fn load_config() -> AppConfig {
         Err(_) => return AppConfig::default(),
     };
 
+    parse_config_body(&content)
+}
+
+fn parse_config_body(content: &str) -> AppConfig {
     let mut config = AppConfig::default();
     for line in content.lines() {
         let line = line.trim();
@@ -79,6 +87,10 @@ pub fn load_config() -> AppConfig {
             };
             if key == "hidden_agents" {
                 config.hidden_agents = parse_string_array(val);
+                continue;
+            }
+            if key == "claude_config_dirs" {
+                config.claude_config_dirs = parse_path_array(val);
                 continue;
             }
             let val = val.trim_matches('"').trim_matches('\'');
@@ -119,6 +131,27 @@ fn parse_string_array(raw: &str) -> Vec<String> {
         .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
         .filter(|s| !s.is_empty())
         .collect()
+}
+
+fn parse_path_array(raw: &str) -> Vec<PathBuf> {
+    parse_string_array(raw)
+        .into_iter()
+        .map(|s| expand_home_path(&s))
+        .collect()
+}
+
+fn expand_home_path(raw: &str) -> PathBuf {
+    if raw == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(raw)
 }
 
 pub fn save_theme(name: &str) -> Result<(), String> {
@@ -210,6 +243,23 @@ mod tests {
         assert!(parse_string_array(r#"["a",,]"#)
             .iter()
             .all(|s| !s.is_empty()));
+    }
+
+    #[test]
+    fn parse_path_array_expands_home_relative_entries() {
+        let home = dirs::home_dir().unwrap();
+        let paths = parse_path_array(r#"["~/.claude-personal", "/tmp/.claude-work"]"#);
+
+        assert_eq!(paths[0], home.join(".claude-personal"));
+        assert_eq!(paths[1], PathBuf::from("/tmp/.claude-work"));
+    }
+
+    #[test]
+    fn parse_config_body_loads_claude_config_dirs() {
+        let home = dirs::home_dir().unwrap();
+        let cfg = parse_config_body(r#"claude_config_dirs = ["~/.claude-personal"]"#);
+
+        assert_eq!(cfg.claude_config_dirs, vec![home.join(".claude-personal")]);
     }
 
     fn theme_update(name: &str) -> Vec<(&'static str, String)> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,10 +79,11 @@ fn main() -> io::Result<()> {
 
     // --once flag: print snapshot and exit
     if std::env::args().any(|a| a == "--once") {
-        let mut app = App::new_with_config(
+        let mut app = App::new_with_config_and_claude_dirs(
             initial_theme.unwrap_or_default(),
             &cfg.hidden_agents,
             cfg.panels,
+            &cfg.claude_config_dirs,
         );
         if demo_mode {
             demo::populate_demo(&mut app);
@@ -115,6 +116,7 @@ fn main() -> io::Result<()> {
         exit_on_jump,
         &cfg.hidden_agents,
         cfg.panels,
+        &cfg.claude_config_dirs,
     );
 
     // Always attempt both cleanup steps regardless of app result
@@ -133,8 +135,14 @@ fn run_app(
     exit_on_jump: bool,
     hidden_agents: &[String],
     panels: config::PanelVisibility,
+    claude_config_dirs: &[std::path::PathBuf],
 ) -> io::Result<()> {
-    let mut app = App::new_with_config(initial_theme.unwrap_or_default(), hidden_agents, panels);
+    let mut app = App::new_with_config_and_claude_dirs(
+        initial_theme.unwrap_or_default(),
+        hidden_agents,
+        panels,
+        claude_config_dirs,
+    );
     if demo_mode {
         demo::populate_demo(&mut app);
     } else {


### PR DESCRIPTION
## Summary
- Add `claude_config_dirs` support for explicit Claude Code profile roots.
- Auto-discover `~/.claude` and `~/.claude-*` roots that contain both `sessions/` and `projects/`.
- Wire configured roots through the app/collector stack and document the config option.

Fixes #123

## Test Plan
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo build`