### PR TITLE
feat: add Config column to sessions table showing profile root

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1123,6 +1123,7 @@ mod tests {
             pending_since_ms: 0,
             thinking_since_ms: 0,
             file_accesses: vec![],
+            config_root: String::new(),
             git_added: 0,
             git_modified: 0,
         }

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -673,6 +673,7 @@ impl ClaudeCollector {
             pending_since_ms: cached.last_assistant_ts_ms,
             thinking_since_ms: cached.last_user_ts_ms,
             file_accesses,
+            config_root: super::abbrev_path(&config.base_dir()),
         })
     }
 

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -291,6 +291,9 @@ impl CodexCollector {
                 pending_since_ms: result.pending_since_ms,
                 thinking_since_ms: result.thinking_since_ms,
                 file_accesses: vec![],
+                config_root: super::abbrev_path(
+                    self.sessions_dir.parent().unwrap_or(std::path::Path::new(".")),
+                ),
             },
             rate_limit,
         ))

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -11,6 +11,16 @@ pub use mcp::McpServer;
 pub use opencode::OpenCodeCollector;
 pub use rate_limit::read_rate_limits;
 
+/// Abbreviate a filesystem path by replacing the home directory prefix with `~`.
+pub(crate) fn abbrev_path(path: &std::path::Path) -> String {
+    if let Some(home) = dirs::home_dir() {
+        if let Ok(rel) = path.strip_prefix(&home) {
+            return format!("~/{}", rel.display());
+        }
+    }
+    path.to_string_lossy().into_owned()
+}
+
 /// Redact common secret patterns to avoid displaying credentials in the TUI.
 /// Replaces the prefix and all following non-whitespace chars with [REDACTED].
 /// Best-effort: covers well-known prefixed tokens, not arbitrary high-entropy strings.

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -195,6 +195,9 @@ impl OpenCodeCollector {
                 pending_since_ms: 0,
                 thinking_since_ms: 0,
                 file_accesses: vec![],
+                config_root: super::abbrev_path(
+                    self.db_path.parent().unwrap_or(std::path::Path::new(".")),
+                ),
             });
         }
 

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -198,6 +198,7 @@ pub fn populate_demo(app: &mut App) {
             ],
             pending_since_ms: now - 6_000, // 6s ago => bar animates
             thinking_since_ms: 0,
+            config_root: "~/.claude".into(),
             file_accesses: vec![
                 FileAccess {
                     path: "src/checkout/payment.rs".into(),
@@ -305,6 +306,7 @@ pub fn populate_demo(app: &mut App) {
             tool_calls: vec![],
             pending_since_ms: 0,
             thinking_since_ms: 0,
+            config_root: "~/.claude-work".into(),
             file_accesses: vec![],
         },
         AgentSession {
@@ -408,6 +410,7 @@ pub fn populate_demo(app: &mut App) {
             // animates. 1s offset keeps the bar visibly growing against the
             // session's 2.8s max tool duration before it caps at 100%.
             thinking_since_ms: now - 1_000,
+            config_root: "~/.claude".into(),
             file_accesses: vec![],
         },
         AgentSession {
@@ -461,6 +464,7 @@ pub fn populate_demo(app: &mut App) {
             tool_calls: vec![],
             pending_since_ms: 0,
             thinking_since_ms: 0,
+            config_root: "~/.codex".into(),
             file_accesses: vec![],
         },
         AgentSession {
@@ -502,6 +506,7 @@ pub fn populate_demo(app: &mut App) {
             tool_calls: vec![],
             pending_since_ms: 0,
             thinking_since_ms: 0,
+            config_root: "~/.local/share/opencode".into(),
             file_accesses: vec![],
         },
     ];

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -40,6 +40,8 @@ static LOCALE_EN: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("col.tokens", "Tokens");
     m.insert("col.memory", "Memory");
     m.insert("col.turn", "Turn");
+    m.insert("col.config", "Config");
+    m.insert("col.cfg", "Cfg");
 
     // Agent labels
     m.insert("agent.claude", "*CC");
@@ -285,6 +287,8 @@ static LOCALE_ZH: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("col.tokens", "Token");
     m.insert("col.memory", "内存");
     m.insert("col.turn", "轮");
+    m.insert("col.config", "配置");
+    m.insert("col.cfg", "配");
 
     // Agent labels
     m.insert("agent.claude", "*CC");

--- a/src/model/session.rs
+++ b/src/model/session.rs
@@ -180,6 +180,10 @@ pub struct AgentSession {
     pub thinking_since_ms: u64,
     /// File access audit log: every file read/written/edited by the agent.
     pub file_accesses: Vec<FileAccess>,
+    /// Config root directory for this session's agent (home-abbreviated, e.g. "~/.claude-work").
+    /// For Claude Code: the active .claude* profile folder. For Codex: "~/.codex".
+    /// For OpenCode: the data directory containing opencode.db.
+    pub config_root: String,
 }
 
 impl AgentSession {
@@ -288,6 +292,7 @@ mod tests {
             pending_since_ms: 0,
             thinking_since_ms: 0,
             file_accesses: Vec::new(),
+            config_root: String::new(),
         }
     }
 

--- a/src/ui/sessions.rs
+++ b/src/ui/sessions.rs
@@ -86,10 +86,11 @@ pub(crate) fn draw_sessions_panel_active(
     let w = inner.width;
     let show_pid = w >= 120;
     let show_session_id = w >= 76;
+    let show_config = w >= 100;
     let show_model = w >= 90;
     let show_tokens = w >= 86;
-    let show_memory = w >= 100;
-    let show_turn = w >= 100;
+    let show_memory = w >= 110;
+    let show_turn = w >= 110;
 
     let project_w: u16 = if w >= 120 {
         14
@@ -103,6 +104,12 @@ pub(crate) fn draw_sessions_panel_active(
         t("col.session")
     } else {
         t("col.sess")
+    };
+    let config_w: u16 = if w >= 110 { 14 } else { 10 };
+    let config_label = if w >= 110 {
+        t("col.config")
+    } else {
+        t("col.cfg")
     };
     let status_w: u16 = if w >= 100 {
         8
@@ -191,6 +198,12 @@ pub(crate) fn draw_sessions_panel_active(
                 Style::default().fg(theme.session_id),
             )));
         }
+        if show_config {
+            cells.push(Cell::from(Span::styled(
+                truncate_str(&session.config_root, config_w as usize),
+                Style::default().fg(theme.inactive_fg),
+            )));
+        }
         cells.extend([
             Cell::from(Span::styled(
                 truncate_str(&summary_col, w.saturating_sub(24) as usize),
@@ -241,10 +254,12 @@ pub(crate) fn draw_sessions_panel_active(
         rows.push(Row::new(cells).style(row_style).height(1));
 
         // 2nd line: task text in Summary column
-        let summary_idx = 3 + show_pid as usize + show_session_id as usize;
+        let summary_idx =
+            3 + show_pid as usize + show_session_id as usize + show_config as usize;
         let total_cols = 6
             + show_pid as usize
             + show_session_id as usize
+            + show_config as usize
             + show_model as usize
             + show_tokens as usize
             + show_memory as usize
@@ -297,6 +312,9 @@ pub(crate) fn draw_sessions_panel_active(
                 if show_session_id {
                     sa_cells.push(Cell::from(""));
                 }
+                if show_config {
+                    sa_cells.push(Cell::from(""));
+                }
                 sa_cells.extend([
                     Cell::from(""),
                     Cell::from(Span::styled(icon, Style::default().fg(sa_fg))),
@@ -336,6 +354,9 @@ pub(crate) fn draw_sessions_panel_active(
     if show_session_id {
         header_cells.push(Cell::from(Span::styled(session_label, header_style)));
     }
+    if show_config {
+        header_cells.push(Cell::from(Span::styled(config_label, header_style)));
+    }
     header_cells.extend([
         Cell::from(Span::styled(t("col.summary"), header_style)),
         Cell::from(Span::styled(t("col.status"), header_style)),
@@ -365,6 +386,9 @@ pub(crate) fn draw_sessions_panel_active(
     widths_vec.push(Constraint::Length(project_w)); // project
     if show_session_id {
         widths_vec.push(Constraint::Length(session_w)); // session id
+    }
+    if show_config {
+        widths_vec.push(Constraint::Length(config_w)); // config root
     }
     widths_vec.push(Constraint::Fill(1)); // summary (fills remaining)
     widths_vec.push(Constraint::Length(status_w)); // status
@@ -1281,6 +1305,7 @@ mod tests {
             pending_since_ms: 0,
             thinking_since_ms: 0,
             file_accesses: Vec::new(),
+            config_root: String::new(),
         });
 
         let backend = TestBackend::new(120, 20);


### PR DESCRIPTION
## Summary

- Adds a **Config** column between Session and Summary in the sessions table, showing the config root directory (e.g. `~/.claude-work`, `~/.codex`, `~/.local/share/opencode`)
- Useful when multiple Claude Code profiles are active simultaneously (via `CLAUDE_CONFIG_DIR` or `~/.claude-*` siblings)
- New `config_root` field on `AgentSession` is populated by all three collectors (Claude, Codex, OpenCode) and home-abbreviated via a shared `abbrev_path` helper in `collector/mod.rs`

## Behaviour

| AI  | Session  | Config            | Summary                    |
|-----|----------|-------------------|----------------------------|
| *CC | a1b2c3d4 | `~/.claude`       | Stripe payment integration |
| *CC | b2c3d4e5 | `~/.claude-work`  | Batch inference endpoint   |
| >CD | d4e5f6a7 | `~/.codex`        | D3 heatmap component       |
| #OC | ses_e5f6 | `~/.local/shar…`  | Terraform multi-region     |

- Column appears at terminal width ≥ 100 (10 chars); expands to 14 chars at ≥ 110
- Memory and Turn columns bumped from ≥ 100 to ≥ 110 to keep layout balanced

## Test plan

- [ ] `cargo test` passes (143 tests)
- [ ] `cargo run -- --demo` shows Config column with varied profile paths across all three agent types
- [ ] Column absent below width 100, present at 100+, wider label at 110+
- [ ] Real Claude session with `CLAUDE_CONFIG_DIR=~/.claude-work` shows correct profile path

Closes #127