### PR TITLE
fix: improve Codex Desktop rollout discovery

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -699,7 +699,7 @@ impl App {
             return;
         }
         let session = &self.sessions[self.selected];
-        if session.status == SessionStatus::Done {
+        if matches!(session.status, SessionStatus::Done | SessionStatus::Unknown) {
             return;
         }
 

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -10,6 +10,8 @@ use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 #[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 use std::process::Command;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::time::{Duration, Instant};
 
 /// Collector for OpenAI Codex CLI sessions.
 ///
@@ -27,6 +29,7 @@ pub struct CodexCollector {
     sessions_dir: PathBuf,
     /// Latest rate limit info parsed from Codex JSONL token_count events.
     pub last_rate_limit: Option<RateLimitInfo>,
+    desktop_recent_scanner: DesktopRecentRolloutScanner,
 }
 
 #[derive(Clone, Copy)]
@@ -34,6 +37,72 @@ struct CodexProcessContext {
     pid: Option<u32>,
     is_exec: bool,
     owns_process_tree: bool,
+    unknown_process_owner: bool,
+}
+
+struct DesktopRecentRolloutScanResult {
+    rollouts: Vec<PathBuf>,
+}
+
+struct DesktopRecentRolloutScanner {
+    cached: Vec<PathBuf>,
+    in_flight: bool,
+    last_started: Option<Instant>,
+    tx: Sender<DesktopRecentRolloutScanResult>,
+    rx: Receiver<DesktopRecentRolloutScanResult>,
+}
+
+const DESKTOP_RECENT_ROLLOUT_RESCAN_INTERVAL: Duration = Duration::from_secs(60);
+
+impl DesktopRecentRolloutScanner {
+    fn new() -> Self {
+        let (tx, rx) = mpsc::channel();
+        Self {
+            cached: Vec::new(),
+            in_flight: false,
+            last_started: None,
+            tx,
+            rx,
+        }
+    }
+
+    fn update(&mut self, sessions_dir: &Path, active_mtime_secs: u64) -> Vec<PathBuf> {
+        self.poll_completed();
+        if self.should_start(sessions_dir) {
+            self.start(sessions_dir.to_path_buf(), active_mtime_secs);
+        }
+        self.cached.clone()
+    }
+
+    fn poll_completed(&mut self) {
+        while let Ok(result) = self.rx.try_recv() {
+            self.cached = result.rollouts;
+            self.in_flight = false;
+        }
+    }
+
+    fn should_start(&self, sessions_dir: &Path) -> bool {
+        if self.in_flight || !sessions_dir.exists() {
+            return false;
+        }
+        self.last_started
+            .is_none_or(|started| started.elapsed() >= DESKTOP_RECENT_ROLLOUT_RESCAN_INTERVAL)
+    }
+
+    fn start(&mut self, sessions_dir: PathBuf, active_mtime_secs: u64) {
+        self.in_flight = true;
+        self.last_started = Some(Instant::now());
+        let tx = self.tx.clone();
+        std::thread::spawn(move || {
+            let rollouts = CodexCollector::recent_desktop_rollouts(
+                &sessions_dir,
+                &HashSet::new(),
+                &HashSet::new(),
+                active_mtime_secs,
+            );
+            let _ = tx.send(DesktopRecentRolloutScanResult { rollouts });
+        });
+    }
 }
 
 impl CodexCollector {
@@ -42,6 +111,7 @@ impl CodexCollector {
         Self {
             sessions_dir: home.join(".codex").join("sessions"),
             last_rate_limit: None,
+            desktop_recent_scanner: DesktopRecentRolloutScanner::new(),
         }
     }
 
@@ -74,6 +144,7 @@ impl CodexCollector {
                     pid: Some(*pid),
                     is_exec,
                     owns_process_tree: true,
+                    unknown_process_owner: false,
                 },
                 jsonl_path,
                 &shared.process_info,
@@ -99,39 +170,107 @@ impl CodexCollector {
             &shared.process_info,
             &shared.mcp_server_pids,
         );
-        let desktop_pid_to_rollouts = super::mcp::map_pid_to_rollouts(&desktop_pids);
+        if !desktop_pids.is_empty() {
+            let desktop_pid_to_rollouts: HashMap<u32, Vec<PathBuf>> = desktop_pids
+                .iter()
+                .filter_map(|pid| {
+                    shared
+                        .desktop_rollout_fd_map
+                        .get(pid)
+                        .map(|paths| (*pid, paths.clone()))
+                })
+                .collect();
 
-        // Codex Desktop app-server keeps old rollout fds open. Only fresh
-        // Desktop-originated rollouts represent currently active threads.
-        for (pid, path) in Self::active_desktop_rollouts(
-            desktop_pid_to_rollouts,
-            &seen_jsonl,
-            &shared.mcp_owned_rollouts,
-            super::mcp::ACTIVE_MTIME_SECS,
-        ) {
-            if let Some((session, rl)) = self.load_session_with_rate_limit(
-                CodexProcessContext {
-                    pid: Some(pid),
+            // Prefer the filesystem view so Desktop sessions appear immediately,
+            // then use the async fd cache only to improve PID ownership.
+            let desktop_pid_for_path = Self::desktop_pid_by_rollout_path(
+                &desktop_pid_to_rollouts,
+                super::mcp::ACTIVE_MTIME_SECS,
+            );
+            let mut desktop_rollout_paths = Self::foreground_desktop_rollouts(
+                &self.sessions_dir,
+                &seen_jsonl,
+                &shared.mcp_owned_rollouts,
+                super::mcp::ACTIVE_MTIME_SECS,
+            );
+            for path in self
+                .desktop_recent_scanner
+                .update(&self.sessions_dir, super::mcp::ACTIVE_MTIME_SECS)
+            {
+                if seen_jsonl.contains(&path) || shared.mcp_owned_rollouts.contains(&path) {
+                    continue;
+                }
+                if !desktop_rollout_paths.contains(&path) {
+                    desktop_rollout_paths.push(path);
+                }
+            }
+            Self::sort_rollouts_by_mtime_desc(&mut desktop_rollout_paths);
+
+            for path in desktop_rollout_paths {
+                let pid = desktop_pid_for_path
+                    .get(&path)
+                    .copied();
+                let process_ctx = CodexProcessContext {
+                    pid,
                     is_exec: false,
                     owns_process_tree: false,
-                },
-                &path,
-                &shared.process_info,
-                &shared.children_map,
-                &shared.ports,
-            ) {
-                seen_jsonl.insert(path);
-                if let Some(new_rl) = rl {
-                    let newer = self
-                        .last_rate_limit
-                        .as_ref()
-                        .is_none_or(|old| new_rl.updated_at > old.updated_at);
-                    if newer {
-                        super::rate_limit::write_codex_cache(&new_rl);
-                        self.last_rate_limit = Some(new_rl);
+                    unknown_process_owner: pid.is_none(),
+                };
+                if let Some((session, rl)) = self.load_session_with_rate_limit(
+                    process_ctx,
+                    &path,
+                    &shared.process_info,
+                    &shared.children_map,
+                    &shared.ports,
+                ) {
+                    seen_jsonl.insert(path);
+                    if let Some(new_rl) = rl {
+                        let newer = self
+                            .last_rate_limit
+                            .as_ref()
+                            .is_none_or(|old| new_rl.updated_at > old.updated_at);
+                        if newer {
+                            super::rate_limit::write_codex_cache(&new_rl);
+                            self.last_rate_limit = Some(new_rl);
+                        }
                     }
+                    sessions.push(session);
                 }
-                sessions.push(session);
+            }
+
+            // Retain fd-only discovery for files not visible in today's active
+            // scan; this is a fallback, not the first-paint path.
+            for (pid, path) in Self::active_desktop_rollouts(
+                desktop_pid_to_rollouts,
+                &seen_jsonl,
+                &shared.mcp_owned_rollouts,
+                super::mcp::ACTIVE_MTIME_SECS,
+            ) {
+                if let Some((session, rl)) = self.load_session_with_rate_limit(
+                    CodexProcessContext {
+                        pid: Some(pid),
+                        is_exec: false,
+                        owns_process_tree: false,
+                        unknown_process_owner: false,
+                    },
+                    &path,
+                    &shared.process_info,
+                    &shared.children_map,
+                    &shared.ports,
+                ) {
+                    seen_jsonl.insert(path);
+                    if let Some(new_rl) = rl {
+                        let newer = self
+                            .last_rate_limit
+                            .as_ref()
+                            .is_none_or(|old| new_rl.updated_at > old.updated_at);
+                        if newer {
+                            super::rate_limit::write_codex_cache(&new_rl);
+                            self.last_rate_limit = Some(new_rl);
+                        }
+                    }
+                    sessions.push(session);
+                }
             }
         }
 
@@ -175,6 +314,7 @@ impl CodexCollector {
                             pid: None,
                             is_exec: false,
                             owns_process_tree: false,
+                            unknown_process_owner: false,
                         },
                         &path,
                         &shared.process_info,
@@ -262,6 +402,132 @@ impl CodexCollector {
             .collect()
     }
 
+    fn desktop_pid_by_rollout_path(
+        pid_to_rollouts: &HashMap<u32, Vec<PathBuf>>,
+        active_mtime_secs: u64,
+    ) -> HashMap<PathBuf, u32> {
+        Self::active_desktop_rollouts(
+            pid_to_rollouts.clone(),
+            &HashSet::new(),
+            &HashSet::new(),
+            active_mtime_secs,
+        )
+        .into_iter()
+        .map(|(pid, path)| (path, pid))
+        .collect()
+    }
+
+    fn foreground_desktop_rollouts(
+        sessions_dir: &Path,
+        seen_jsonl: &HashSet<PathBuf>,
+        mcp_owned_rollouts: &HashSet<PathBuf>,
+        active_mtime_secs: u64,
+    ) -> Vec<PathBuf> {
+        let Some(today_dir) = Self::today_session_dir(sessions_dir) else {
+            return Vec::new();
+        };
+        let roots = [today_dir];
+        Self::recent_desktop_rollouts_from_roots(
+            &roots,
+            seen_jsonl,
+            mcp_owned_rollouts,
+            active_mtime_secs,
+        )
+    }
+
+    fn recent_desktop_rollouts_from_roots(
+        roots: &[PathBuf],
+        seen_jsonl: &HashSet<PathBuf>,
+        mcp_owned_rollouts: &HashSet<PathBuf>,
+        active_mtime_secs: u64,
+    ) -> Vec<PathBuf> {
+        let mut candidates = Vec::new();
+        for root in roots {
+            Self::collect_recent_desktop_rollouts(
+                root,
+                seen_jsonl,
+                mcp_owned_rollouts,
+                active_mtime_secs,
+                &mut candidates,
+            );
+        }
+        Self::sort_rollouts_by_mtime_desc(&mut candidates);
+        candidates
+    }
+
+    fn recent_desktop_rollouts(
+        sessions_dir: &Path,
+        seen_jsonl: &HashSet<PathBuf>,
+        mcp_owned_rollouts: &HashSet<PathBuf>,
+        active_mtime_secs: u64,
+    ) -> Vec<PathBuf> {
+        let mut candidates = Vec::new();
+        Self::collect_recent_desktop_rollouts(
+            sessions_dir,
+            seen_jsonl,
+            mcp_owned_rollouts,
+            active_mtime_secs,
+            &mut candidates,
+        );
+        Self::sort_rollouts_by_mtime_desc(&mut candidates);
+        candidates
+    }
+
+    fn sort_rollouts_by_mtime_desc(paths: &mut [PathBuf]) {
+        paths.sort_by_key(|path| {
+            std::cmp::Reverse(
+                fs::metadata(path)
+                    .and_then(|meta| meta.modified())
+                    .unwrap_or(std::time::UNIX_EPOCH),
+            )
+        });
+    }
+
+    fn collect_recent_desktop_rollouts(
+        dir: &Path,
+        seen_jsonl: &HashSet<PathBuf>,
+        mcp_owned_rollouts: &HashSet<PathBuf>,
+        active_mtime_secs: u64,
+        candidates: &mut Vec<PathBuf>,
+    ) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            let path = entry.path();
+            if file_type.is_dir() {
+                Self::collect_recent_desktop_rollouts(
+                    &path,
+                    seen_jsonl,
+                    mcp_owned_rollouts,
+                    active_mtime_secs,
+                    candidates,
+                );
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !name.starts_with("rollout-") || !name.ends_with(".jsonl") {
+                continue;
+            }
+            if seen_jsonl.contains(&path) || mcp_owned_rollouts.contains(&path) {
+                continue;
+            }
+            if Self::is_active_desktop_rollout(&path, active_mtime_secs) {
+                candidates.push(path);
+            }
+        }
+    }
+
     fn load_session_with_rate_limit(
         &self,
         process_ctx: CodexProcessContext,
@@ -292,7 +558,9 @@ impl CodexCollector {
         // Mirrors Claude: trust the trailing-event-is-user signal alone.
         // Codex tool outputs flow through response_item, not user_message,
         // so model_generating only flips on real prompts.
-        let status = if !pid_alive || (process_ctx.is_exec && result.task_complete) {
+        let status = if process_ctx.unknown_process_owner {
+            SessionStatus::Unknown
+        } else if !pid_alive || (process_ctx.is_exec && result.task_complete) {
             SessionStatus::Done
         } else {
             let has_active_child = process_ctx.owns_process_tree
@@ -313,6 +581,8 @@ impl CodexCollector {
         // For interactive sessions, task_complete fires after every turn — ignore it.
         let current_tasks = if !result.current_task.is_empty() {
             vec![result.current_task]
+        } else if matches!(status, SessionStatus::Unknown) {
+            vec!["unknown".to_string()]
         } else if !pid_alive || (process_ctx.is_exec && result.task_complete) {
             vec!["finished".to_string()]
         } else if matches!(status, SessionStatus::Waiting) {
@@ -396,7 +666,9 @@ impl CodexCollector {
                 thinking_since_ms: result.thinking_since_ms,
                 file_accesses: vec![],
                 config_root: super::abbrev_path(
-                    self.sessions_dir.parent().unwrap_or(std::path::Path::new(".")),
+                    self.sessions_dir
+                        .parent()
+                        .unwrap_or(std::path::Path::new(".")),
                 ),
             },
             rate_limit,
@@ -447,7 +719,7 @@ impl CodexCollector {
 
     /// Find Codex Desktop app-server host PIDs. Desktop is kept separate from
     /// CLI discovery because a single app-server PID can hold many rollout fds.
-    fn find_codex_desktop_pids_from_shared(
+    pub(crate) fn find_codex_desktop_pids_from_shared(
         process_info: &HashMap<u32, ProcInfo>,
         mcp_server_pids: &HashSet<u32>,
     ) -> Vec<u32> {
@@ -1177,6 +1449,7 @@ mod tests {
             pid: Some(pid),
             is_exec: false,
             owns_process_tree: true,
+            unknown_process_owner: false,
         }
     }
 
@@ -1185,6 +1458,7 @@ mod tests {
             pid: Some(pid),
             is_exec: false,
             owns_process_tree: false,
+            unknown_process_owner: false,
         }
     }
 
@@ -1350,6 +1624,60 @@ mod tests {
     }
 
     #[test]
+    fn recent_desktop_rollouts_include_active_sessions_from_older_day_dirs() {
+        let sessions = tempfile::tempdir().unwrap();
+        let today = CodexCollector::today_session_dir(sessions.path()).unwrap_or_else(|| {
+            let now = chrono::Local::now();
+            sessions
+                .path()
+                .join(now.format("%Y").to_string())
+                .join(now.format("%m").to_string())
+                .join(now.format("%d").to_string())
+        });
+        let older = sessions.path().join("2026").join("05").join("20");
+        fs::create_dir_all(&today).unwrap();
+        fs::create_dir_all(&older).unwrap();
+        let active = today.join("rollout-active.jsonl");
+        let older_active = older.join("rollout-older-active.jsonl");
+        let stale = today.join("rollout-stale.jsonl");
+        let cli = today.join("rollout-cli.jsonl");
+        write_jsonl(&active, &[DESKTOP_SESSION_META]);
+        write_jsonl(&older_active, &[DESKTOP_SESSION_META]);
+        write_jsonl(&stale, &[DESKTOP_SESSION_META]);
+        write_jsonl(&cli, &[SESSION_META]);
+        set_modified(&stale, SystemTime::now() - Duration::from_secs(31 * 60));
+
+        let rollouts = CodexCollector::recent_desktop_rollouts(
+            sessions.path(),
+            &HashSet::new(),
+            &HashSet::new(),
+            super::super::mcp::ACTIVE_MTIME_SECS,
+        );
+
+        assert_eq!(rollouts.len(), 2);
+        assert!(rollouts.contains(&active));
+        assert!(rollouts.contains(&older_active));
+    }
+
+    #[test]
+    fn desktop_pid_by_rollout_path_uses_active_fd_cache_only_for_ownership() {
+        let temp = tempfile::tempdir().unwrap();
+        let active = temp.path().join("rollout-active.jsonl");
+        let stale = temp.path().join("rollout-stale.jsonl");
+        write_jsonl(&active, &[DESKTOP_SESSION_META]);
+        write_jsonl(&stale, &[DESKTOP_SESSION_META]);
+        set_modified(&stale, SystemTime::now() - Duration::from_secs(31 * 60));
+        let pid_to_rollouts = HashMap::from([(99, vec![active.clone(), stale])]);
+
+        let by_path = CodexCollector::desktop_pid_by_rollout_path(
+            &pid_to_rollouts,
+            super::super::mcp::ACTIVE_MTIME_SECS,
+        );
+
+        assert_eq!(by_path, HashMap::from([(active, 99)]));
+    }
+
+    #[test]
     fn desktop_rollout_selection_loads_active_session_with_host_pid() {
         let temp = tempfile::tempdir().unwrap();
         let active = temp.path().join("rollout-active.jsonl");
@@ -1402,6 +1730,51 @@ mod tests {
         assert_eq!(sessions[0].status, SessionStatus::Waiting);
         assert_eq!(sessions[0].mem_mb, 0);
         assert!(sessions[0].children.is_empty());
+    }
+
+    #[test]
+    fn desktop_filesystem_only_rollout_is_unknown_without_fd_owner() {
+        let sessions = tempfile::tempdir().unwrap();
+        let today = sessions.path().join(
+            chrono::Local::now()
+                .format("%Y/%m/%d")
+                .to_string(),
+        );
+        fs::create_dir_all(&today).unwrap();
+        let active = today.join("rollout-active.jsonl");
+        write_jsonl(&active, &[DESKTOP_SESSION_META]);
+
+        let mut collector = CodexCollector {
+            sessions_dir: sessions.path().to_path_buf(),
+            last_rate_limit: None,
+            desktop_recent_scanner: DesktopRecentRolloutScanner::new(),
+        };
+        let mut shared = super::super::SharedProcessData {
+            process_info: HashMap::new(),
+            children_map: HashMap::new(),
+            ports: HashMap::new(),
+            slow_tick: false,
+            mcp_server_pids: HashSet::new(),
+            mcp_owned_rollouts: HashSet::new(),
+            mcp_suppress: true,
+            desktop_rollout_fd_map: HashMap::new(),
+        };
+        shared.process_info.insert(
+            99,
+            proc_info(
+                99,
+                1,
+                "/Applications/Codex.app/Contents/Resources/codex app-server --analytics-default-enabled",
+            ),
+        );
+
+        let sessions = collector.collect_sessions(&shared);
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].pid, 0);
+        assert_eq!(sessions[0].session_id, "desktop-123");
+        assert_eq!(sessions[0].status, SessionStatus::Unknown);
+        assert_eq!(sessions[0].current_tasks, vec!["unknown".to_string()]);
     }
 
     #[test]

--- a/src/collector/mcp.rs
+++ b/src/collector/mcp.rs
@@ -357,6 +357,10 @@ pub(crate) fn kill_rollout_scan_child(pid: u32) {
     kill_pid(pid);
 }
 
+#[cfg(any(
+    test,
+    all(not(target_os = "linux"), not(target_os = "windows"))
+))]
 pub(crate) fn parse_lsof_rollout_output(stdout: &str) -> HashMap<u32, Vec<PathBuf>> {
     let mut map: HashMap<u32, Vec<PathBuf>> = HashMap::new();
     let mut current_pid: Option<u32> = None;

--- a/src/collector/mcp.rs
+++ b/src/collector/mcp.rs
@@ -2,8 +2,8 @@ use super::process::{self, ProcInfo};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 #[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
-use std::process::Command;
-use std::time::SystemTime;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime};
 
 /// Active-thread mtime threshold: a rollout written within the last 30 minutes
 /// ACTIVE_MTIME_SECS counts as "active". File-descriptor presence alone
@@ -263,22 +263,113 @@ pub(crate) fn map_pid_to_rollouts(pids: &[u32]) -> HashMap<u32, Vec<PathBuf>> {
         let output = Command::new("lsof").args(&args).output().ok();
         if let Some(output) = output {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            let mut current_pid: Option<u32> = None;
-            for line in stdout.lines() {
-                if let Some(pid_str) = line.strip_prefix('p') {
-                    current_pid = pid_str.parse::<u32>().ok();
-                } else if let Some(name) = line.strip_prefix('n') {
-                    if let Some(pid) = current_pid {
-                        let path = PathBuf::from(name);
-                        if is_rollout_path(&path) {
-                            map.entry(pid).or_default().push(path);
-                        }
+            map = parse_lsof_rollout_output(&stdout);
+        }
+    }
+
+    map
+}
+
+pub(crate) fn map_pid_to_rollouts_with_timeout_and_pid_slot(
+    pids: &[u32],
+    timeout: Duration,
+    child_pid_slot: Option<std::sync::Arc<std::sync::atomic::AtomicU32>>,
+) -> Option<HashMap<u32, Vec<PathBuf>>> {
+    if pids.is_empty() {
+        return Some(HashMap::new());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        let _ = (timeout, child_pid_slot);
+        Some(map_pid_to_rollouts(pids))
+    }
+
+    #[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
+    {
+        let pid_args: Vec<String> = pids.iter().map(|p| format!("-p{}", p)).collect();
+        let mut args = vec!["-F", "pn"];
+        for pa in &pid_args {
+            args.push(pa);
+        }
+
+        let output_file = tempfile::NamedTempFile::new().ok()?;
+        let output_for_child = output_file.reopen().ok()?;
+        let mut child = match Command::new("lsof")
+            .args(&args)
+            .stdout(Stdio::from(output_for_child))
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(_) => return None,
+        };
+        let child_pid = child.id();
+        if let Some(slot) = &child_pid_slot {
+            slot.store(child_pid, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        let started = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    if let Some(slot) = &child_pid_slot {
+                        slot.store(0, std::sync::atomic::Ordering::SeqCst);
                     }
+                    let stdout = std::fs::read_to_string(output_file.path()).ok();
+                    return stdout.map(|s| parse_lsof_rollout_output(&s));
+                }
+                Ok(None) if started.elapsed() >= timeout => {
+                    if let Some(slot) = &child_pid_slot {
+                        slot.store(0, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    let _ = Command::new("kill")
+                        .args(["-9", &child_pid.to_string()])
+                        .status();
+                    let _ = child.wait();
+                    return None;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(100)),
+                Err(_) => {
+                    if let Some(slot) = &child_pid_slot {
+                        slot.store(0, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    return None;
                 }
             }
         }
     }
+}
 
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
+fn kill_pid(pid: u32) {
+    if pid != 0 {
+        let _ = Command::new("kill").args(["-9", &pid.to_string()]).status();
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn kill_pid(_pid: u32) {}
+
+pub(crate) fn kill_rollout_scan_child(pid: u32) {
+    kill_pid(pid);
+}
+
+pub(crate) fn parse_lsof_rollout_output(stdout: &str) -> HashMap<u32, Vec<PathBuf>> {
+    let mut map: HashMap<u32, Vec<PathBuf>> = HashMap::new();
+    let mut current_pid: Option<u32> = None;
+    for line in stdout.lines() {
+        if let Some(pid_str) = line.strip_prefix('p') {
+            current_pid = pid_str.parse::<u32>().ok();
+        } else if let Some(name) = line.strip_prefix('n') {
+            if let Some(pid) = current_pid {
+                let path = PathBuf::from(name);
+                if is_rollout_path(&path) {
+                    map.entry(pid).or_default().push(path);
+                }
+            }
+        }
+    }
     map
 }
 
@@ -369,5 +460,33 @@ mod tests {
         };
         assert!(!stale.is_active(now, ACTIVE_MTIME_SECS));
         assert!(fresh.is_active(now, ACTIVE_MTIME_SECS));
+    }
+
+    #[test]
+    fn parses_lsof_rollout_output_for_multiple_pids_and_paths() {
+        let stdout = "\
+p100
+n/Users/me/.codex/sessions/2026/05/29/rollout-a.jsonl
+n/Users/me/.codex/sessions/2026/05/29/not-a-rollout.txt
+p200
+n/Users/me/.codex/sessions/2026/05/29/rollout-b.jsonl
+n/Users/me/.codex/sessions/2026/05/29/rollout-c.jsonl
+";
+
+        let parsed = parse_lsof_rollout_output(stdout);
+
+        assert_eq!(
+            parsed.get(&100),
+            Some(&vec![PathBuf::from(
+                "/Users/me/.codex/sessions/2026/05/29/rollout-a.jsonl"
+            )])
+        );
+        assert_eq!(
+            parsed.get(&200),
+            Some(&vec![
+                PathBuf::from("/Users/me/.codex/sessions/2026/05/29/rollout-b.jsonl"),
+                PathBuf::from("/Users/me/.codex/sessions/2026/05/29/rollout-c.jsonl"),
+            ])
+        );
     }
 }

--- a/src/collector/mcp.rs
+++ b/src/collector/mcp.rs
@@ -3,7 +3,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 #[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant, SystemTime};
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
+use std::time::Instant;
+use std::time::{Duration, SystemTime};
 
 /// Active-thread mtime threshold: a rollout written within the last 30 minutes
 /// ACTIVE_MTIME_SECS counts as "active". File-descriptor presence alone

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -85,6 +85,12 @@ pub(crate) fn sanitize_terminal_text(s: &str) -> String {
 use crate::model::{AgentSession, OrphanPort, RateLimitInfo, SessionStatus};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    mpsc::{self, Receiver, Sender},
+    Arc,
+};
+use std::time::{Duration, Instant};
 
 /// Trait for agent-specific session collectors.
 /// Implement this to add support for a new AI coding agent.
@@ -127,6 +133,9 @@ pub struct SharedProcessData {
     /// sessions panel restores upstream behavior. Driven by the user
     /// toggle (Shift+M).
     pub mcp_suppress: bool,
+    /// Cached Desktop app-server PID -> open rollout files. This is populated
+    /// by a background scanner so slow macOS lsof calls cannot block the TUI.
+    pub desktop_rollout_fd_map: HashMap<u32, Vec<PathBuf>>,
 }
 
 impl SharedProcessData {
@@ -146,6 +155,7 @@ impl SharedProcessData {
             mcp_server_pids: HashSet::new(),
             mcp_owned_rollouts: HashSet::new(),
             mcp_suppress: true,
+            desktop_rollout_fd_map: HashMap::new(),
         }
     }
 }
@@ -158,9 +168,108 @@ struct TrackedPortChild {
     project_name: String,
 }
 
+struct DesktopRolloutScanResult {
+    pids: Vec<u32>,
+    rollouts: Option<HashMap<u32, Vec<PathBuf>>>,
+}
+
+struct DesktopRolloutScanner {
+    cached: HashMap<u32, Vec<PathBuf>>,
+    cached_pids: Vec<u32>,
+    in_flight_pids: Option<Vec<u32>>,
+    child_pid: Arc<AtomicU32>,
+    last_started: Option<Instant>,
+    tx: Sender<DesktopRolloutScanResult>,
+    rx: Receiver<DesktopRolloutScanResult>,
+}
+
+const DESKTOP_ROLLOUT_SCAN_TIMEOUT: Duration = Duration::from_secs(90);
+const DESKTOP_ROLLOUT_RESCAN_INTERVAL: Duration = Duration::from_secs(60);
+
+impl DesktopRolloutScanner {
+    fn new() -> Self {
+        let (tx, rx) = mpsc::channel();
+        Self {
+            cached: HashMap::new(),
+            cached_pids: Vec::new(),
+            in_flight_pids: None,
+            child_pid: Arc::new(AtomicU32::new(0)),
+            last_started: None,
+            tx,
+            rx,
+        }
+    }
+
+    fn update(&mut self, pids: &[u32]) -> HashMap<u32, Vec<PathBuf>> {
+        self.poll_completed();
+        if self.should_start(pids) {
+            self.start(pids.to_vec());
+        }
+        self.cached_for(pids)
+    }
+
+    fn poll_completed(&mut self) {
+        while let Ok(result) = self.rx.try_recv() {
+            self.apply_result(result);
+        }
+    }
+
+    fn apply_result(&mut self, result: DesktopRolloutScanResult) {
+        self.in_flight_pids = None;
+        if let Some(rollouts) = result.rollouts {
+            self.cached_pids = result.pids;
+            self.cached = rollouts;
+        }
+    }
+
+    fn should_start(&self, pids: &[u32]) -> bool {
+        if pids.is_empty() || self.in_flight_pids.is_some() {
+            return false;
+        }
+        if self.cached_pids != pids {
+            return true;
+        }
+        self.last_started
+            .is_none_or(|started| started.elapsed() >= DESKTOP_ROLLOUT_RESCAN_INTERVAL)
+    }
+
+    fn start(&mut self, pids: Vec<u32>) {
+        self.in_flight_pids = Some(pids.clone());
+        self.last_started = Some(Instant::now());
+        let tx = self.tx.clone();
+        let child_pid = self.child_pid.clone();
+        std::thread::spawn(move || {
+            let rollouts = mcp::map_pid_to_rollouts_with_timeout_and_pid_slot(
+                &pids,
+                DESKTOP_ROLLOUT_SCAN_TIMEOUT,
+                Some(child_pid),
+            );
+            let _ = tx.send(DesktopRolloutScanResult { pids, rollouts });
+        });
+    }
+
+    fn cached_for(&self, pids: &[u32]) -> HashMap<u32, Vec<PathBuf>> {
+        let mut map = HashMap::new();
+        for pid in pids {
+            if let Some(paths) = self.cached.get(pid) {
+                map.insert(*pid, paths.clone());
+            }
+        }
+        map
+    }
+}
+
+impl Drop for DesktopRolloutScanner {
+    fn drop(&mut self) {
+        let pid = self.child_pid.swap(0, Ordering::SeqCst);
+        mcp::kill_rollout_scan_child(pid);
+    }
+}
+
 /// Aggregates sessions from multiple collectors (Claude, Codex, etc.)
 pub struct MultiCollector {
     collectors: Vec<Box<dyn AgentCollector>>,
+    codex_enabled: bool,
     tick_count: u32,
     cached_ports: HashMap<u32, Vec<u16>>,
     /// PID set snapshot from last port scan — invalidate cache when PIDs change.
@@ -178,6 +287,7 @@ pub struct MultiCollector {
     /// behavior (mcp-server PIDs and their rollouts appear there too,
     /// with the existing 1-of-N HashMap-overwrite caveat).
     pub mcp_suppress: bool,
+    desktop_rollout_scanner: DesktopRolloutScanner,
 }
 
 /// How often to refresh expensive I/O (in ticks). 5 ticks × 2s = 10s.
@@ -209,8 +319,10 @@ impl MultiCollector {
         if !is_hidden("opencode") {
             collectors.push(Box::new(OpenCodeCollector::new()));
         }
+        let codex_enabled = !is_hidden("codex");
         Self {
             collectors,
+            codex_enabled,
             tick_count: SLOW_POLL_INTERVAL, // trigger on first tick
             cached_ports: HashMap::new(),
             cached_port_pids: Vec::new(),
@@ -219,6 +331,7 @@ impl MultiCollector {
             orphan_ports: Vec::new(),
             mcp_servers: Vec::new(),
             mcp_suppress: true,
+            desktop_rollout_scanner: DesktopRolloutScanner::new(),
         }
     }
 
@@ -272,6 +385,14 @@ impl MultiCollector {
         if self.mcp_suppress {
             shared.mcp_server_pids = detection.server_pids;
             shared.mcp_owned_rollouts = detection.owned_rollouts;
+        }
+
+        if self.codex_enabled {
+            let desktop_pids = CodexCollector::find_codex_desktop_pids_from_shared(
+                &shared.process_info,
+                &shared.mcp_server_pids,
+            );
+            shared.desktop_rollout_fd_map = self.desktop_rollout_scanner.update(&desktop_pids);
         }
 
         let mut all = Vec::new();
@@ -401,5 +522,31 @@ mod tests {
             "opencode".to_string(),
         ]);
         assert!(mc.collectors.is_empty());
+    }
+
+    #[test]
+    fn desktop_rollout_scanner_keeps_cache_on_failed_result() {
+        let mut scanner = DesktopRolloutScanner::new();
+        let mut cached = HashMap::new();
+        cached.insert(42, vec![PathBuf::from("/tmp/rollout-live.jsonl")]);
+
+        scanner.apply_result(DesktopRolloutScanResult {
+            pids: vec![42],
+            rollouts: Some(cached.clone()),
+        });
+        scanner.apply_result(DesktopRolloutScanResult {
+            pids: vec![42],
+            rollouts: None,
+        });
+
+        assert_eq!(scanner.cached_for(&[42]), cached);
+    }
+
+    #[test]
+    fn desktop_rollout_scanner_in_flight_guard_blocks_duplicate_scan() {
+        let mut scanner = DesktopRolloutScanner::new();
+        scanner.in_flight_pids = Some(vec![42]);
+
+        assert!(!scanner.should_start(&[42]));
     }
 }

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -23,6 +23,7 @@ static LOCALE_EN: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("sess.think", "◉ Think");
     m.insert("sess.exec", "● Exec");
     m.insert("sess.wait", "◌ Wait");
+    m.insert("sess.unknown", "? Unknown");
     m.insert("sess.rate", "⏳ Rate");
     m.insert("sess.done", "✓ Done");
 
@@ -270,6 +271,7 @@ static LOCALE_ZH: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("sess.think", "◉ 思考");
     m.insert("sess.exec", "● 执行");
     m.insert("sess.wait", "◌ 等待");
+    m.insert("sess.unknown", "? Unknown");
     m.insert("sess.rate", "⏳ 限速");
     m.insert("sess.done", "✓ 完成");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,6 +350,7 @@ fn print_snapshot(app: &App) {
             model::SessionStatus::Thinking => "◉ Think",
             model::SessionStatus::Executing => "● Exec",
             model::SessionStatus::Waiting => "◌ Wait",
+            model::SessionStatus::Unknown => "? Unknown",
             model::SessionStatus::RateLimited => "⏳ Rate",
             model::SessionStatus::Done => "✓ Done",
         };

--- a/src/model/session.rs
+++ b/src/model/session.rs
@@ -57,6 +57,8 @@ pub enum SessionStatus {
     Executing,
     /// Idle, waiting for user input or permission prompt
     Waiting,
+    /// Session appears recent, but process ownership is not confirmed
+    Unknown,
     /// Waiting due to rate limit
     RateLimited,
     /// Session finished

--- a/src/ui/sessions.rs
+++ b/src/ui/sessions.rs
@@ -150,6 +150,7 @@ pub(crate) fn draw_sessions_panel_active(
             crate::model::SessionStatus::Thinking => (t("sess.think"), theme.proc_misc),
             crate::model::SessionStatus::Executing => (t("sess.exec"), theme.hi_fg),
             crate::model::SessionStatus::Waiting => (t("sess.wait"), grad_at(&proc_grad, 50.0)),
+            crate::model::SessionStatus::Unknown => (t("sess.unknown"), theme.inactive_fg),
             crate::model::SessionStatus::RateLimited => (t("sess.rate"), theme.status_fg),
             crate::model::SessionStatus::Done => (t("sess.done"), theme.inactive_fg),
         };
@@ -1062,6 +1063,7 @@ fn draw_timeline(
             crate::model::SessionStatus::Thinking
                 | crate::model::SessionStatus::Executing
                 | crate::model::SessionStatus::Waiting
+                | crate::model::SessionStatus::Unknown
         );
     if tool_calls.is_empty() && !is_thinking {
         return;


### PR DESCRIPTION
## Summary

This PR fixes UI stalls when many Codex Desktop `app-server` processes are running.

Previously, Codex Desktop rollout discovery could call `lsof -F pn -p...` synchronously on the TUI refresh path. On macOS, that command can take tens of seconds when many Desktop threads/processes are open, which makes startup, refresh, panel switching, and keyboard interaction feel frozen.

## Changes

- Move Codex Desktop rollout fd discovery to a background scanner.
- Add a 90-second timeout for the Desktop `lsof` worker.
- Keep the previous successful fd cache when a scan fails or times out.
- Ensure only one Desktop rollout fd scan can run at a time.
- Use cached Desktop fd data through `SharedProcessData.desktop_rollout_fd_map`.
- Avoid changing regular Codex CLI session discovery; `map_pid_to_jsonl()` still follows the existing synchronous CLI path.
- Add filesystem-based recent Desktop rollout discovery so the first screen is not empty while fd scanning is still pending.
- Include recent active Desktop sessions from older date directories, not only today's directory.
- Add an `Unknown` session status for recent Desktop sessions whose rollout file is visible but PID ownership is not yet confirmed.
- Preserve existing active mtime filtering, seen rollout deduplication, and MCP-owned rollout exclusion.

## Why

Codex Desktop can keep many rollout files and process fds around. Blocking the main TUI thread on `lsof` makes the app appear broken or unresponsive. The new path lets the UI render immediately using filesystem-discovered active rollouts, while fd ownership is filled in asynchronously when available.

## Validation

- `cargo test`
- `cargo build`
- `cargo build --release`
- Built test binary:
  `/Users/yanxin/GitHub/abtop/target/distrib/abtop-codex-desktop-fix`

## Risk

Low to moderate.

The change is scoped to Codex Desktop/app-server rollout discovery. Regular Codex CLI, Claude, OpenCode, ports, git stats, and MCP panel behavior are intentionally left mostly unchanged. The main tradeoff is that some Desktop sessions may briefly show `Unknown` until the background fd scan confirms ownership.