### PR TITLE
fix(windows): host metrics via sysinfo + OpenCode session discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo install abtop
 
 ### Windows
 
-Native support — no WSL required. Uses `sysinfo` for process info and `netstat -ano` for listening ports.
+Native support — no WSL required. Uses `sysinfo` for process info and host CPU/MEM metrics, and `netstat -ano` for listening ports. Windows has no load average, so LOAD is reported as 0. OpenCode session discovery additionally requires the `sqlite3` CLI (`winget install SQLite.SQLite`); without it abtop prints a one-time warning to stderr.
 
 ```powershell
 powershell -c "irm https://github.com/graykode/abtop/releases/latest/download/abtop-installer.ps1 | iex"
@@ -83,7 +83,7 @@ tmux new -s work
 | Subagents         |     ✅      |    ❌     |    ❌    |
 | Memory Status     |     ✅      |    ❌     |    ❌    |
 
-OpenCode support reads the local SQLite database at `~/.local/share/opencode/opencode.db` and requires `sqlite3` in `PATH`.
+OpenCode support reads the local SQLite database at `~/.local/share/opencode/opencode.db` (also the default location on Windows; `%LOCALAPPDATA%\opencode` and `%APPDATA%\opencode` are probed as fallbacks) and requires `sqlite3` in `PATH` (on Windows: `winget install SQLite.SQLite`).
 
 ## Themes
 

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -2038,14 +2038,17 @@ mod tests {
     }
 
     fn write_session_file(path: &Path, pid: u32, session_id: &str, cwd: &Path) {
+        // Serialize via serde_json so Windows backslash paths are escaped
+        // correctly instead of producing invalid JSON.
         std::fs::write(
             path,
-            format!(
-                r#"{{"pid":{},"sessionId":"{}","cwd":"{}","startedAt":1774715116826}}"#,
-                pid,
-                session_id,
-                cwd.display()
-            ),
+            serde_json::json!({
+                "pid": pid,
+                "sessionId": session_id,
+                "cwd": cwd.to_str().unwrap(),
+                "startedAt": 1774715116826u64,
+            })
+            .to_string(),
         )
         .unwrap();
     }

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -1477,7 +1477,10 @@ mod tests {
     }
 
     fn set_modified(path: &Path, when: SystemTime) {
-        File::open(path).unwrap().set_modified(when).unwrap();
+        // Open with write access: on Windows, setting timestamps through a
+        // read-only handle fails with PermissionDenied.
+        let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(when).unwrap();
     }
 
     #[cfg(windows)]

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -26,6 +26,9 @@ pub struct OpenCodeCollector {
     sqlite3_available: Option<bool>,
     /// Cached DB rows from the last slow-tick query. Reused on fast ticks.
     cached_db_sessions: Vec<DbSession>,
+    /// Whether the "sqlite3 missing" warning has been emitted (once).
+    #[cfg(target_os = "windows")]
+    warned_sqlite3_missing: bool,
 }
 
 impl OpenCodeCollector {
@@ -33,10 +36,15 @@ impl OpenCodeCollector {
         let data_dir = std::env::var("XDG_DATA_HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".local/share"));
+        let db_path = data_dir.join("opencode").join("opencode.db");
+        #[cfg(target_os = "windows")]
+        let db_path = windows_db_path(db_path);
         Self {
-            db_path: data_dir.join("opencode").join("opencode.db"),
+            db_path,
             sqlite3_available: None,
             cached_db_sessions: Vec::new(),
+            #[cfg(target_os = "windows")]
+            warned_sqlite3_missing: false,
         }
     }
 
@@ -51,7 +59,24 @@ impl OpenCodeCollector {
 
     fn collect_sessions(&mut self, shared: &super::SharedProcessData) -> Vec<AgentSession> {
         // Security: skip if db_path is a symlink (fail-closed)
-        if is_symlink(&self.db_path) || !self.db_path.exists() || !self.check_sqlite3() {
+        if is_symlink(&self.db_path) || !self.db_path.exists() {
+            self.cached_db_sessions.clear();
+            return vec![];
+        }
+        if !self.check_sqlite3() {
+            // The DB exists but we can't read it: on Windows sqlite3 is
+            // usually not preinstalled, so say why sessions are missing
+            // instead of failing silently.
+            #[cfg(target_os = "windows")]
+            if !self.warned_sqlite3_missing {
+                self.warned_sqlite3_missing = true;
+                eprintln!(
+                    "abtop: OpenCode database found at {} but the `sqlite3` CLI is not on PATH; \
+                     OpenCode sessions will not appear. Install it (e.g. `winget install SQLite.SQLite`) \
+                     and restart abtop.",
+                    self.db_path.display()
+                );
+            }
             self.cached_db_sessions.clear();
             return vec![];
         }
@@ -115,7 +140,10 @@ impl OpenCodeCollector {
             let project_name = if !ds.project_name.is_empty() {
                 ds.project_name.clone()
             } else {
-                ds.directory.rsplit('/').next().unwrap_or("?").to_string()
+                // last_path_segment also splits on `\` on Windows.
+                process::last_path_segment(&ds.directory)
+                    .unwrap_or("?")
+                    .to_string()
             };
 
             let current_tasks = if matches!(status, SessionStatus::Waiting) {
@@ -252,7 +280,7 @@ impl OpenCodeCollector {
                 continue;
             }
             if let Some(cwd) = get_process_cwd(pid) {
-                if cwd == session_dir {
+                if paths_equal(&cwd, session_dir) {
                     return Some(pid);
                 }
             }
@@ -424,8 +452,49 @@ fn truncate_field(s: &mut String, max_bytes: usize) {
     }
 }
 
+/// Compare a process cwd with a DB session directory.
+/// On Windows paths are case-insensitive and may mix `/` and `\`, so
+/// normalize before comparing; elsewhere keep the exact comparison.
+#[cfg(target_os = "windows")]
+fn paths_equal(a: &str, b: &str) -> bool {
+    let norm = |s: &str| {
+        s.replace('/', "\\")
+            .trim_end_matches('\\')
+            .to_ascii_lowercase()
+    };
+    norm(a) == norm(b)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn paths_equal(a: &str, b: &str) -> bool {
+    a == b
+}
+
+/// On Windows, OpenCode builds (e.g. installed via npm) have been observed to
+/// keep the XDG-style `~/.local/share/opencode` layout, so prefer the same
+/// path as unix; fall back to probing `%LOCALAPPDATA%` / `%APPDATA%` in case
+/// a build stores the DB there instead.
+#[cfg(target_os = "windows")]
+fn windows_db_path(default: PathBuf) -> PathBuf {
+    if default.exists() {
+        return default;
+    }
+    for var in ["LOCALAPPDATA", "APPDATA"] {
+        if let Ok(base) = std::env::var(var) {
+            if base.is_empty() {
+                continue;
+            }
+            let candidate = PathBuf::from(base).join("opencode").join("opencode.db");
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+    default
+}
+
 /// Get the current working directory of a process.
-/// Uses /proc on Linux, lsof on macOS/other Unix.
+/// Uses /proc on Linux, sysinfo (PEB) on Windows, lsof on macOS/other Unix.
 #[cfg(target_os = "linux")]
 fn get_process_cwd(pid: u32) -> Option<String> {
     std::fs::read_link(format!("/proc/{}/cwd", pid))
@@ -433,7 +502,25 @@ fn get_process_cwd(pid: u32) -> Option<String> {
         .map(|p| p.to_string_lossy().into_owned())
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")]
+fn get_process_cwd(pid: u32) -> Option<String> {
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+    // `lsof` does not exist on Windows; sysinfo reads the cwd from the
+    // process PEB. Refresh just this one PID — this runs only for the
+    // handful of opencode PIDs, once per tick.
+    let mut sys = System::new();
+    let pid = Pid::from_u32(pid);
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::new().with_cwd(UpdateKind::Always),
+    );
+    sys.process(pid)
+        .and_then(|p| p.cwd())
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 fn get_process_cwd(pid: u32) -> Option<String> {
     // -a ANDs the selection terms; without it, lsof ORs `-p <pid>` with
     // `-d cwd` and returns cwd entries for unrelated processes too.

--- a/src/host_info.rs
+++ b/src/host_info.rs
@@ -210,9 +210,9 @@ mod windows_impl {
             }
             let mem_pct = (self.sys.used_memory() as f64 / total as f64) * 100.0;
 
-            // Windows has no load average; sysinfo reports 0.0 there. Callers
-            // should render load as N/A on Windows.
-            let load1 = System::load_average().one;
+            // Windows has no native load average. Keep the wire shape stable
+            // by reporting 0.0 rather than using sysinfo's approximation.
+            let load1 = 0.0;
 
             Some(HostMetrics {
                 cpu_pct,

--- a/src/host_info.rs
+++ b/src/host_info.rs
@@ -1,8 +1,8 @@
 //! Lightweight host vitals: CPU%, MEM%, 1-min load average.
 //!
-//! Reads `/proc` directly on Linux. Returns `None` on other platforms (for now);
-//! callers should treat absence as "metrics unavailable" and render a graceful
-//! fallback.
+//! Reads `/proc` directly on Linux and uses `sysinfo` on Windows. Returns
+//! `None` on other platforms (for now); callers should treat absence as
+//! "metrics unavailable" and render a graceful fallback.
 
 use serde::Serialize;
 
@@ -17,12 +17,18 @@ pub struct HostMetrics {
 }
 
 /// Stateful sampler that remembers the previous `/proc/stat` snapshot so it
-/// can compute CPU usage as a delta between ticks.
+/// can compute CPU usage as a delta between ticks. On Windows it instead
+/// holds a `sysinfo::System` across ticks for the same reason: CPU usage is
+/// a delta between two refreshes.
 #[derive(Debug, Default)]
 pub struct HostSampler {
+    #[cfg(not(target_os = "windows"))]
     prev: Option<CpuTimes>,
+    #[cfg(target_os = "windows")]
+    win: windows_impl::WinSampler,
 }
 
+#[cfg(not(target_os = "windows"))]
 #[derive(Debug, Clone, Copy)]
 struct CpuTimes {
     /// All non-idle jiffies (user + nice + system + irq + softirq + steal).
@@ -36,8 +42,9 @@ impl HostSampler {
         Self::default()
     }
 
-    /// Sample current host metrics. Returns `None` if /proc is unavailable
-    /// (non-Linux, or first sample where no CPU delta exists yet).
+    /// Sample current host metrics. Returns `None` if the platform has no
+    /// metrics source (non-Linux unix, for now).
+    #[cfg(not(target_os = "windows"))]
     pub fn sample(&mut self) -> Option<HostMetrics> {
         let cpu_pct = self.sample_cpu()?;
         let mem_pct = sample_mem()?;
@@ -49,6 +56,14 @@ impl HostSampler {
         })
     }
 
+    /// Windows: CPU/MEM via `sysinfo`. There is no load average on Windows,
+    /// so `load1` is reported as 0.0 (callers should label it N/A).
+    #[cfg(target_os = "windows")]
+    pub fn sample(&mut self) -> Option<HostMetrics> {
+        self.win.sample()
+    }
+
+    #[cfg(not(target_os = "windows"))]
     fn sample_cpu(&mut self) -> Option<f64> {
         let now = read_cpu_times()?;
         let pct = match self.prev {
@@ -129,17 +144,83 @@ fn sample_load() -> Option<f64> {
     s.split_whitespace().next().and_then(|n| n.parse().ok())
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 fn read_cpu_times() -> Option<CpuTimes> {
     None
 }
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 fn sample_mem() -> Option<f64> {
     None
 }
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 fn sample_load() -> Option<f64> {
     None
+}
+
+/// Windows host metrics via `sysinfo` (already a Windows-only dependency).
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use super::HostMetrics;
+    use sysinfo::System;
+
+    /// Holds a `System` across ticks: `sysinfo` computes CPU usage as the
+    /// delta between two refreshes, so a freshly constructed `System` always
+    /// reports 0. The collector tick (~2s) is well above
+    /// `sysinfo::MINIMUM_CPU_UPDATE_INTERVAL`.
+    pub struct WinSampler {
+        sys: System,
+        /// False until the first refresh has happened; the first sample has
+        /// no CPU delta yet, so report 0.0 (mirrors the Linux first-tick
+        /// behavior where `prev` is `None`).
+        primed: bool,
+    }
+
+    impl Default for WinSampler {
+        fn default() -> Self {
+            Self {
+                sys: System::new(),
+                primed: false,
+            }
+        }
+    }
+
+    impl std::fmt::Debug for WinSampler {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("WinSampler")
+                .field("primed", &self.primed)
+                .finish()
+        }
+    }
+
+    impl WinSampler {
+        pub fn sample(&mut self) -> Option<HostMetrics> {
+            self.sys.refresh_cpu_usage();
+            self.sys.refresh_memory();
+
+            let cpu_pct = if self.primed {
+                self.sys.global_cpu_usage() as f64
+            } else {
+                0.0
+            };
+            self.primed = true;
+
+            let total = self.sys.total_memory();
+            if total == 0 {
+                return None;
+            }
+            let mem_pct = (self.sys.used_memory() as f64 / total as f64) * 100.0;
+
+            // Windows has no load average; sysinfo reports 0.0 there. Callers
+            // should render load as N/A on Windows.
+            let load1 = System::load_average().one;
+
+            Some(HostMetrics {
+                cpu_pct,
+                mem_pct,
+                load1,
+            })
+        }
+    }
 }
 
 /// Aggregate per-session metrics into a single agent-wide summary.

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -24,8 +24,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub struct Snapshot {
     /// Unix-epoch milliseconds when this snapshot was built.
     pub generated_at_ms: u64,
-    /// Host vitals (CPU / mem / load1). `None` on non-Linux or before the
-    /// first valid sample.
+    /// Host vitals (CPU / mem / load1). `None` on unsupported platforms or
+    /// before the first valid sample.
     pub host: Option<HostMetrics>,
     /// Aggregate metrics across all sessions.
     pub aggregate: AgentAggregate,


### PR DESCRIPTION
## Summary
On Windows 11 abtop showed **"n/a" host metrics** and **0 OpenCode sessions** even with an agent running (reported by an abtop-web-ui tester; reproduces with the TUI and `abtop --json`). This PR fixes both **on Windows only** — every runtime change is `#[cfg(target_os = "windows")]`-gated and the Linux `/proc` path and macOS stub are byte-for-byte unchanged.

## Host metrics (`src/host_info.rs`)
`HostSampler::sample()` returned `None` on every non-Linux platform. `sysinfo` is already a Windows-only dependency, so the sampler now holds a `sysinfo::System` across ticks (CPU usage is a delta between two refreshes — mirrors the Linux prev/delta design): `cpu_pct` = global CPU (0.0 on the first tick, same as Linux), `mem_pct` = used/total, `load1` = 0.0 (Windows has no load average; rendered as N/A).

## OpenCode session discovery (`src/collector/opencode.rs`)
Three Windows-only root causes, found by debugging on a real Windows 11 machine:
1. **`get_process_cwd()` shelled out to `lsof`** (the `not(linux)` branch), which doesn't exist on Windows → cwd matching always failed. New `#[cfg(windows)]` impl reads the cwd via sysinfo (process PEB), refreshing only the queried PID.
2. **Path-format mismatch**: the OpenCode DB stores `directory` with forward slashes (`C:/Users/x/proj` — verified against a real DB) while the live process cwd has backslashes, and NTFS is case-insensitive. Windows-gated `paths_equal()` normalizes separators + case; unix keeps the exact comparison.
3. **Silent empty result when the `sqlite3` CLI is missing** — the common case on Windows. When the DB exists but sqlite3 isn't on PATH, a one-time stderr warning names the DB path and the install command (`winget install SQLite.SQLite`).

Also: `%LOCALAPPDATA%` / `%APPDATA%` are probed as DB-path fallbacks (npm-installed OpenCode keeps the XDG-style `~/.local/share` layout on Windows, so the existing default already resolves), and the project-name fallback goes through `last_path_segment()` so backslash paths don't leak a full path as the project name.

## Windows test suite (pre-existing failures)
`cargo test` had 18 pre-existing failures on Windows — two **fixture** bugs, not product bugs: `claude.rs write_session_file()` built JSON with `format!` (backslash paths → invalid escapes; 14 tests saw zero sessions), now serialized with `serde_json`; `codex.rs set_modified()` opened the file read-only before `File::set_modified()` (`PermissionDenied` on Windows; 4 panics), now opens with write access like `claude.rs set_mtime()` already did.

## Verification
- Windows 11 (MSVC): `cargo build` + `cargo test` green (163/163); `abtop --json` shows real CPU/MEM and the OpenCode session matched by cwd; warning path verified with sqlite3 removed from PATH
- Linux: `cargo build` + `cargo test` green (165 passed + doc-test, 0 failed, verified on real Linux x86_64 before opening this PR); `abtop --json` confirmed unchanged — host metrics from `/proc`, session discovery identical
- macOS: `cargo check --target aarch64-apple-darwin` passes (no code path changes outside `#[cfg(windows)]`)
- README: Windows section + OpenCode notes updated

Thanks for abtop! 