### PR TITLE
Add user-defined theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ OpenCode support reads the local SQLite database at `~/.local/share/opencode/ope
 
 ## Themes
 
-12 built-in themes, including 4 colorblind-friendly options (`high-contrast`, `protanopia`, `deuteranopia`, `tritanopia`). Press `t` to cycle at runtime, or launch with `--theme <name>`. Your choice is saved to `~/.config/abtop/config.toml`.
+12 built-in themes, including 4 colorblind-friendly options (`high-contrast`, `protanopia`, `deuteranopia`, `tritanopia`). Press `t` to cycle built-in and configured custom themes at runtime, or launch with `--theme <name>`. Your choice is saved to `~/.config/abtop/config.toml`.
 
 | btop (default) | dracula | catppuccin |
 |:-:|:-:|:-:|
@@ -128,6 +128,49 @@ hidden_agents = ["codex"]
 claude_config_dirs = ["~/.claude-personal", "~/.claude-work-team"]
 # UI language. Omit or leave empty to auto-detect from LANG.
 language = "zh"
+```
+
+### Custom themes
+
+Define custom themes in the same config file with `[themes.<name>]`, then set `theme = "<name>"` or launch `abtop --theme <name>`. Custom themes are appended to the `t` cycle after built-ins. Names matching built-ins do not override built-ins. Malformed color/gradient values are ignored and inherit from the base theme; config values are parsed as data only, with no code execution.
+
+Exact schema:
+
+```toml
+theme = "midnight"
+
+[themes.midnight]
+# Optional built-in base to inherit from. Defaults to "btop".
+base = "dracula"
+
+# Color fields accept quoted #RRGGBB values. Any omitted or malformed field
+# inherits from base.
+main_bg = "#101018"
+main_fg = "#e6e6f0"
+title = "#ffffff"
+hi_fg = "#ff79c6"
+selected_bg = "#303050"
+selected_fg = "#ffffff"
+inactive_fg = "#666680"
+graph_text = "#8888aa"
+meter_bg = "#24243a"
+proc_misc = "#50fa7b"
+div_line = "#303050"
+session_id = "#f1fa8c"
+status_fg = "#ff5555"
+warning_fg = "#f1fa8c"
+cpu_box = "#8be9fd"
+mem_box = "#bd93f9"
+net_box = "#ff79c6"
+proc_box = "#ff5555"
+
+# Gradient fields are arrays of three quoted #RRGGBB values:
+# [low, mid, high].
+cpu_grad = ["#50fa7b", "#f1fa8c", "#ff5555"]
+proc_grad = ["#50fa7b", "#f1fa8c", "#ff5555"]
+used_grad = ["#44475a", "#ff79c6", "#ff5555"]
+free_grad = ["#282a36", "#50fa7b", "#8be9fd"]
+cached_grad = ["#282a36", "#8be9fd", "#bd93f9"]
 ```
 
 ### Supported Languages

--- a/src/app.rs
+++ b/src/app.rs
@@ -471,17 +471,18 @@ impl App {
     }
 
     pub fn cycle_theme(&mut self) {
-        let names = crate::theme::THEME_NAMES;
+        let cfg = crate::config::load_config();
+        let names = crate::theme::available_theme_names(&cfg.custom_themes);
         let current = names
             .iter()
-            .position(|&n| n == self.theme.name)
+            .position(|name| name.as_str() == self.theme.name.as_str())
             .unwrap_or(0);
-        let next = (current + 1) % names.len();
-        self.theme = Theme::by_name(names[next]).unwrap_or_default();
-        if let Err(e) = crate::config::save_theme(names[next]) {
-            self.set_status(format!("theme: {} (save failed: {})", names[next], e));
+        let next_name = &names[(current + 1) % names.len()];
+        self.theme = Theme::from_config_name(next_name, &cfg.custom_themes).unwrap_or_default();
+        if let Err(e) = crate::config::save_theme(next_name) {
+            self.set_status(format!("theme: {} (save failed: {})", next_name, e));
         } else {
-            self.set_status(format!("theme: {}", names[next]));
+            self.set_status(format!("theme: {}", next_name));
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 #[derive(Clone, Copy)]
@@ -25,6 +26,12 @@ impl Default for PanelVisibility {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CustomThemeConfig {
+    pub name: String,
+    pub values: BTreeMap<String, String>,
+}
+
 pub struct AppConfig {
     pub theme: String,
     /// Agent CLI names to exclude from the TUI (e.g. ["codex"] to hide Codex).
@@ -37,6 +44,9 @@ pub struct AppConfig {
     /// UI language override. Empty string means auto-detect from `LANG`.
     /// Recognized values: "en", "zh" (anything starting with "zh" maps to Simplified Chinese).
     pub language: String,
+    /// User-defined theme sections from `[themes.<name>]`. Values remain raw
+    /// so the theme module can validate color-specific syntax.
+    pub custom_themes: Vec<CustomThemeConfig>,
 }
 
 impl Default for AppConfig {
@@ -47,6 +57,7 @@ impl Default for AppConfig {
             claude_config_dirs: Vec::new(),
             panels: PanelVisibility::default(),
             language: String::new(),
+            custom_themes: Vec::new(),
         }
     }
 }
@@ -71,20 +82,35 @@ pub fn load_config() -> AppConfig {
 
 fn parse_config_body(content: &str) -> AppConfig {
     let mut config = AppConfig::default();
-    for line in content.lines() {
-        let line = line.trim();
+    let mut current_custom_theme: Option<String> = None;
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim();
         if line.starts_with('#') || line.is_empty() {
             continue;
         }
+
+        if let Some(section) = parse_section_header(line) {
+            current_custom_theme = section
+                .strip_prefix("themes.")
+                .filter(|name| !name.trim().is_empty())
+                .map(|name| name.trim().to_string());
+            continue;
+        }
+
         if let Some((key, val)) = line.split_once('=') {
             let key = key.trim();
-            // Strip quotes (double or single) and inline comments
-            let val = val.trim();
-            let val = if let Some(comment_pos) = val.find('#') {
-                val[..comment_pos].trim()
-            } else {
-                val
-            };
+            let val = strip_inline_comment(val.trim());
+
+            if let Some(name) = &current_custom_theme {
+                if !key.is_empty() {
+                    custom_theme_mut(&mut config.custom_themes, name)
+                        .values
+                        .insert(key.to_string(), val.to_string());
+                }
+                continue;
+            }
+
             if key == "hidden_agents" {
                 config.hidden_agents = parse_string_array(val);
                 continue;
@@ -93,7 +119,7 @@ fn parse_config_body(content: &str) -> AppConfig {
                 config.claude_config_dirs = parse_path_array(val);
                 continue;
             }
-            let val = val.trim_matches('"').trim_matches('\'');
+            let val = val.trim_matches('\"').trim_matches('\'');
             match key {
                 "theme" => config.theme = val.to_string(),
                 "language" => config.language = val.to_string(),
@@ -109,6 +135,52 @@ fn parse_config_body(content: &str) -> AppConfig {
         }
     }
     config
+}
+
+fn parse_section_header(line: &str) -> Option<&str> {
+    let line = strip_inline_comment(line);
+    let inner = line.strip_prefix('[')?.strip_suffix(']')?.trim();
+    if inner.is_empty() {
+        None
+    } else {
+        Some(inner)
+    }
+}
+
+fn custom_theme_mut<'a>(
+    themes: &'a mut Vec<CustomThemeConfig>,
+    name: &str,
+) -> &'a mut CustomThemeConfig {
+    if let Some(pos) = themes.iter().position(|theme| theme.name == name) {
+        return &mut themes[pos];
+    }
+    themes.push(CustomThemeConfig {
+        name: name.to_string(),
+        values: BTreeMap::new(),
+    });
+    themes.last_mut().expect("just pushed custom theme")
+}
+
+fn strip_inline_comment(raw: &str) -> &str {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (idx, ch) in raw.char_indices() {
+        match ch {
+            '\\' if in_double => {
+                escaped = !escaped;
+                continue;
+            }
+            '"' if !in_single && !escaped => in_double = !in_double,
+            '\'' if !in_double => in_single = !in_single,
+            '#' if !in_single && !in_double => return raw[..idx].trim(),
+            _ => {}
+        }
+        escaped = false;
+    }
+
+    raw.trim()
 }
 
 fn parse_bool(raw: &str) -> Option<bool> {
@@ -193,8 +265,21 @@ fn write_with_updates(updates: &[(&str, String)]) -> Result<(), String> {
 fn rewrite_kv_lines(content: &str, updates: &[(&str, String)]) -> String {
     let mut found = vec![false; updates.len()];
     let mut out: Vec<String> = Vec::new();
+    let mut in_section = false;
+    let mut appended_missing = false;
+
     for line in content.lines() {
-        let line_key = line.split_once('=').map(|(k, _)| k.trim().to_string());
+        let starts_section = parse_section_header(line.trim()).is_some();
+        if starts_section && !appended_missing {
+            append_missing_updates(&mut out, updates, &found);
+            appended_missing = true;
+        }
+
+        let line_key = if in_section {
+            None
+        } else {
+            line.split_once('=').map(|(k, _)| k.trim().to_string())
+        };
         let mut replaced = false;
         if let Some(key) = line_key {
             if let Some(idx) = updates.iter().position(|(k, _)| *k == key) {
@@ -206,13 +291,24 @@ fn rewrite_kv_lines(content: &str, updates: &[(&str, String)]) -> String {
         if !replaced {
             out.push(line.to_string());
         }
+        if starts_section {
+            in_section = true;
+        }
     }
+
+    if !appended_missing {
+        append_missing_updates(&mut out, updates, &found);
+    }
+
+    out.join("\n") + "\n"
+}
+
+fn append_missing_updates(out: &mut Vec<String>, updates: &[(&str, String)], found: &[bool]) {
     for (idx, (k, v)) in updates.iter().enumerate() {
         if !found[idx] {
             out.push(format!("{} = {}", k, v));
         }
     }
-    out.join("\n") + "\n"
 }
 
 #[cfg(test)]
@@ -262,6 +358,46 @@ mod tests {
         assert_eq!(cfg.claude_config_dirs, vec![home.join(".claude-personal")]);
     }
 
+    #[test]
+    fn parse_config_body_loads_custom_theme_sections() {
+        let cfg = parse_config_body(
+            r##"
+theme = "midnight" # active custom theme
+[themes.midnight]
+base = "dracula"
+main_bg = "#101010"
+cpu_grad = ["#000000", "#111111", "#ffffff"]
+"##,
+        );
+
+        assert_eq!(cfg.theme, "midnight");
+        assert_eq!(cfg.custom_themes.len(), 1);
+        assert_eq!(cfg.custom_themes[0].name, "midnight");
+        assert_eq!(
+            cfg.custom_themes[0]
+                .values
+                .get("main_bg")
+                .map(String::as_str),
+            Some("\"#101010\"")
+        );
+        assert_eq!(
+            cfg.custom_themes[0]
+                .values
+                .get("cpu_grad")
+                .map(String::as_str),
+            Some("[\"#000000\", \"#111111\", \"#ffffff\"]")
+        );
+    }
+
+    #[test]
+    fn strip_inline_comment_preserves_hash_inside_quotes() {
+        assert_eq!(
+            strip_inline_comment(r##""#101010" # color"##),
+            r##""#101010""##
+        );
+        assert_eq!(strip_inline_comment("true # comment"), "true");
+    }
+
     fn theme_update(name: &str) -> Vec<(&'static str, String)> {
         vec![("theme", format!("\"{}\"", name))]
     }
@@ -292,6 +428,22 @@ mod tests {
         let after = rewrite_kv_lines(before, &theme_update("gruvbox"));
         assert!(after.contains("hidden_agents = [\"codex\"]"));
         assert!(after.contains("theme = \"gruvbox\""));
+    }
+
+    #[test]
+    fn rewrite_theme_appends_before_custom_theme_section() {
+        let before = "[themes.midnight]\nmain_bg = \"#101010\"\n";
+        let after = rewrite_kv_lines(before, &theme_update("midnight"));
+        assert!(after.starts_with("theme = \"midnight\"\n[themes.midnight]"));
+        assert!(after.contains("main_bg = \"#101010\""));
+    }
+
+    #[test]
+    fn rewrite_theme_ignores_theme_keys_inside_sections() {
+        let before = "theme = \"btop\"\n[themes.midnight]\ntheme = \"not-a-root-key\"\n";
+        let after = rewrite_kv_lines(before, &theme_update("dracula"));
+        assert!(after.contains("theme = \"dracula\"\n[themes.midnight]"));
+        assert!(after.contains("theme = \"not-a-root-key\""));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,10 @@ pub fn run() -> io::Result<()> {
         return Ok(());
     }
 
-    // Load config once; it drives both the default theme and the hidden-agents list.
+    // Load config once; it drives the default theme, user themes, and hidden-agent list.
     let cfg = config::load_config();
+    let available_theme_names = theme::available_theme_names(&cfg.custom_themes);
+    let available_theme_list = available_theme_names.join(", ");
 
     // --theme flag > config file > default
     let initial_theme = std::env::args()
@@ -117,27 +119,26 @@ pub fn run() -> io::Result<()> {
                 Some(name) if !name.starts_with('-') => name,
                 Some(name) => {
                     eprintln!("--theme requires a theme name, got '{}'", name);
-                    eprintln!("available: {}", theme::THEME_NAMES.join(", "));
+                    eprintln!("available: {}", available_theme_list);
                     std::process::exit(1);
                 }
                 None => {
                     eprintln!("--theme requires a theme name");
-                    eprintln!("available: {}", theme::THEME_NAMES.join(", "));
+                    eprintln!("available: {}", available_theme_list);
                     std::process::exit(1);
                 }
             }
         })
         .map(|name| {
-            theme::Theme::by_name(&name).unwrap_or_else(|| {
+            theme::Theme::from_config_name(&name, &cfg.custom_themes).unwrap_or_else(|| {
                 eprintln!(
                     "unknown theme '{}'. available: {}",
-                    name,
-                    theme::THEME_NAMES.join(", ")
+                    name, available_theme_list
                 );
                 std::process::exit(1);
             })
         })
-        .or_else(|| theme::Theme::by_name(&cfg.theme));
+        .or_else(|| theme::Theme::from_config_name(&cfg.theme, &cfg.custom_themes));
 
     let demo_mode = std::env::args().any(|a| a == "--demo");
     let exit_on_jump = std::env::args().any(|a| a == "--exit-on-jump");

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,7 @@
+use crate::config::CustomThemeConfig;
 use ratatui::style::Color;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Gradient {
     pub start: (u8, u8, u8),
     pub mid: (u8, u8, u8),
@@ -7,7 +9,7 @@ pub struct Gradient {
 }
 
 pub struct Theme {
-    pub name: &'static str,
+    pub name: String,
 
     // base
     pub main_bg: Color,
@@ -81,10 +83,24 @@ impl Theme {
         }
     }
 
+    pub fn from_config_name(name: &str, custom_themes: &[CustomThemeConfig]) -> Option<Self> {
+        Self::by_name(name).or_else(|| custom_theme_by_name(name, custom_themes))
+    }
+
+    pub fn available_names(custom_themes: &[CustomThemeConfig]) -> Vec<String> {
+        let mut names: Vec<String> = THEME_NAMES.iter().map(|name| (*name).to_string()).collect();
+        for custom in custom_themes {
+            if !names.iter().any(|name| name == &custom.name) {
+                names.push(custom.name.clone());
+            }
+        }
+        names
+    }
+
     /// btop default — exact RGB values from btop_theme.cpp Default_theme
     pub fn btop() -> Self {
         Self {
-            name: "btop",
+            name: "btop".to_string(),
             main_bg: Color::Rgb(25, 25, 25),
             main_fg: Color::Rgb(204, 204, 204),
             title: Color::Rgb(238, 238, 238),
@@ -133,7 +149,7 @@ impl Theme {
 
     pub fn dracula() -> Self {
         Self {
-            name: "dracula",
+            name: "dracula".to_string(),
             main_bg: Color::Rgb(40, 42, 54),
             main_fg: Color::Rgb(248, 248, 242),
             title: Color::Rgb(248, 248, 242),
@@ -183,7 +199,7 @@ impl Theme {
     pub fn catppuccin() -> Self {
         // Catppuccin Mocha palette
         Self {
-            name: "catppuccin",
+            name: "catppuccin".to_string(),
             main_bg: Color::Rgb(30, 30, 46),
             main_fg: Color::Rgb(205, 214, 244),
             title: Color::Rgb(205, 214, 244),
@@ -233,7 +249,7 @@ impl Theme {
     pub fn tokyo_night() -> Self {
         // Tokyo Night — night variant
         Self {
-            name: "tokyo-night",
+            name: "tokyo-night".to_string(),
             main_bg: Color::Rgb(26, 27, 38),        // bg #1a1b26
             main_fg: Color::Rgb(169, 177, 214),     // fg_dark #a9b1d6
             title: Color::Rgb(192, 202, 245),       // fg #c0caf5
@@ -283,7 +299,7 @@ impl Theme {
     pub fn gruvbox() -> Self {
         // gruvbox dark — bright accent variants for TUI visibility
         Self {
-            name: "gruvbox",
+            name: "gruvbox".to_string(),
             main_bg: Color::Rgb(40, 40, 40),        // bg0 #282828
             main_fg: Color::Rgb(235, 219, 178),     // fg1 #ebdbb2
             title: Color::Rgb(251, 241, 199),       // fg0 #fbf1c7
@@ -333,7 +349,7 @@ impl Theme {
     pub fn nord() -> Self {
         // Nord — arctic color palette
         Self {
-            name: "nord",
+            name: "nord".to_string(),
             main_bg: Color::Rgb(46, 52, 64),        // nord0 #2e3440
             main_fg: Color::Rgb(216, 222, 233),     // nord4 #d8dee9
             title: Color::Rgb(236, 239, 244),       // nord6 #eceff4
@@ -384,7 +400,7 @@ impl Theme {
     /// muted accents for users on bright terminals.
     pub fn light() -> Self {
         Self {
-            name: "light",
+            name: "light".to_string(),
             main_bg: Color::Rgb(253, 246, 227), // base3 #fdf6e3
             main_fg: Color::Rgb(88, 110, 117),  // base01 #586e75
             title: Color::Rgb(7, 54, 66),       // base02 #073642
@@ -435,7 +451,7 @@ impl Theme {
     /// crisp accent colors for users on bright terminals.
     pub fn white() -> Self {
         Self {
-            name: "white",
+            name: "white".to_string(),
             main_bg: Color::Rgb(255, 255, 255),     // white
             main_fg: Color::Rgb(31, 35, 40),        // gh fg.default #1f2328
             title: Color::Rgb(0, 0, 0),             // black
@@ -487,7 +503,7 @@ impl Theme {
     /// any color vision deficiency).
     pub fn high_contrast() -> Self {
         Self {
-            name: "high-contrast",
+            name: "high-contrast".to_string(),
             main_bg: Color::Rgb(0, 0, 0),
             main_fg: Color::Rgb(255, 255, 255),
             title: Color::Rgb(255, 255, 255),
@@ -539,7 +555,7 @@ impl Theme {
     /// magenta #DC267F, orange #FE6100, yellow #FFB000.
     pub fn protanopia() -> Self {
         Self {
-            name: "protanopia",
+            name: "protanopia".to_string(),
             main_bg: Color::Rgb(20, 20, 32),
             main_fg: Color::Rgb(220, 220, 220),
             title: Color::Rgb(255, 255, 255),
@@ -591,7 +607,7 @@ impl Theme {
     /// distinguish most reliably.
     pub fn deuteranopia() -> Self {
         Self {
-            name: "deuteranopia",
+            name: "deuteranopia".to_string(),
             main_bg: Color::Rgb(18, 24, 40),
             main_fg: Color::Rgb(222, 222, 230),
             title: Color::Rgb(255, 255, 255),
@@ -642,7 +658,7 @@ impl Theme {
     /// confusion. Inspired by GitHub's tritanopia-friendly colors.
     pub fn tritanopia() -> Self {
         Self {
-            name: "tritanopia",
+            name: "tritanopia".to_string(),
             main_bg: Color::Rgb(24, 20, 22),
             main_fg: Color::Rgb(224, 224, 224),
             title: Color::Rgb(255, 255, 255),
@@ -690,6 +706,93 @@ impl Theme {
     }
 }
 
+pub fn available_theme_names(custom_themes: &[CustomThemeConfig]) -> Vec<String> {
+    Theme::available_names(custom_themes)
+}
+
+fn custom_theme_by_name(name: &str, custom_themes: &[CustomThemeConfig]) -> Option<Theme> {
+    let custom = custom_themes.iter().find(|theme| theme.name == name)?;
+    let base_name = custom
+        .values
+        .get("base")
+        .map(|raw| unquote(raw))
+        .unwrap_or("btop");
+    let mut theme = Theme::by_name(base_name).unwrap_or_default();
+    theme.name = custom.name.clone();
+
+    for (key, raw) in &custom.values {
+        match key.as_str() {
+            "base" => {}
+            "main_bg" => set_color(&mut theme.main_bg, raw),
+            "main_fg" => set_color(&mut theme.main_fg, raw),
+            "title" => set_color(&mut theme.title, raw),
+            "hi_fg" => set_color(&mut theme.hi_fg, raw),
+            "selected_bg" => set_color(&mut theme.selected_bg, raw),
+            "selected_fg" => set_color(&mut theme.selected_fg, raw),
+            "inactive_fg" => set_color(&mut theme.inactive_fg, raw),
+            "graph_text" => set_color(&mut theme.graph_text, raw),
+            "meter_bg" => set_color(&mut theme.meter_bg, raw),
+            "proc_misc" => set_color(&mut theme.proc_misc, raw),
+            "div_line" => set_color(&mut theme.div_line, raw),
+            "session_id" => set_color(&mut theme.session_id, raw),
+            "status_fg" => set_color(&mut theme.status_fg, raw),
+            "warning_fg" => set_color(&mut theme.warning_fg, raw),
+            "cpu_box" => set_color(&mut theme.cpu_box, raw),
+            "mem_box" => set_color(&mut theme.mem_box, raw),
+            "net_box" => set_color(&mut theme.net_box, raw),
+            "proc_box" => set_color(&mut theme.proc_box, raw),
+            "cpu_grad" => set_gradient(&mut theme.cpu_grad, raw),
+            "proc_grad" => set_gradient(&mut theme.proc_grad, raw),
+            "used_grad" => set_gradient(&mut theme.used_grad, raw),
+            "free_grad" => set_gradient(&mut theme.free_grad, raw),
+            "cached_grad" => set_gradient(&mut theme.cached_grad, raw),
+            _ => {}
+        }
+    }
+
+    Some(theme)
+}
+
+fn set_color(target: &mut Color, raw: &str) {
+    if let Some((r, g, b)) = parse_rgb(raw) {
+        *target = Color::Rgb(r, g, b);
+    }
+}
+
+fn set_gradient(target: &mut Gradient, raw: &str) {
+    if let Some(gradient) = parse_gradient(raw) {
+        *target = gradient;
+    }
+}
+
+fn parse_gradient(raw: &str) -> Option<Gradient> {
+    let inner = raw.trim().strip_prefix('[')?.strip_suffix(']')?;
+    let parts: Vec<&str> = inner.split(',').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let start = parse_rgb(parts[0])?;
+    let mid = parse_rgb(parts[1])?;
+    let end = parse_rgb(parts[2])?;
+    Some(Gradient { start, mid, end })
+}
+
+fn parse_rgb(raw: &str) -> Option<(u8, u8, u8)> {
+    let value = unquote(raw.trim());
+    let hex = value.strip_prefix('#')?;
+    if hex.len() != 6 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some((r, g, b))
+}
+
+fn unquote(raw: &str) -> &str {
+    raw.trim().trim_matches('"').trim_matches('\'')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -710,5 +813,98 @@ mod tests {
     fn default_is_btop() {
         let t = Theme::default();
         assert_eq!(t.name, "btop");
+    }
+
+    #[test]
+    fn custom_theme_inherits_base_and_overrides_fields() {
+        let custom = CustomThemeConfig {
+            name: "midnight".to_string(),
+            values: [
+                ("base", r#""dracula""#),
+                ("main_bg", r##""#010203""##),
+                ("cpu_grad", r##"["#000000", "#111111", "#ffffff"]"##),
+            ]
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect(),
+        };
+
+        let theme = Theme::from_config_name("midnight", &[custom]).unwrap();
+
+        assert_eq!(theme.name, "midnight");
+        assert_eq!(theme.main_bg, Color::Rgb(1, 2, 3));
+        assert_eq!(theme.main_fg, Theme::dracula().main_fg);
+        assert_eq!(theme.cpu_grad.start, (0, 0, 0));
+        assert_eq!(theme.cpu_grad.mid, (17, 17, 17));
+        assert_eq!(theme.cpu_grad.end, (255, 255, 255));
+    }
+
+    #[test]
+    fn malformed_custom_theme_values_fall_back_to_base() {
+        let base = Theme::dracula();
+        let custom = CustomThemeConfig {
+            name: "broken".to_string(),
+            values: [
+                ("base", r#""dracula""#),
+                ("main_bg", r#""010203""#),
+                ("main_fg", r##""#nothex""##),
+                ("cpu_grad", r##"["#000000", "#111111"]"##),
+            ]
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect(),
+        };
+
+        let theme = Theme::from_config_name("broken", &[custom]).unwrap();
+
+        assert_eq!(theme.name, "broken");
+        assert_eq!(theme.main_bg, base.main_bg);
+        assert_eq!(theme.main_fg, base.main_fg);
+        assert_eq!(theme.cpu_grad, base.cpu_grad);
+    }
+
+    #[test]
+    fn custom_theme_with_unknown_base_falls_back_to_btop() {
+        let custom = CustomThemeConfig {
+            name: "unknown-base".to_string(),
+            values: [("base", r#""not-a-theme""#)]
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect(),
+        };
+
+        let theme = Theme::from_config_name("unknown-base", &[custom]).unwrap();
+
+        assert_eq!(theme.name, "unknown-base");
+        assert_eq!(theme.main_bg, Theme::btop().main_bg);
+    }
+
+    #[test]
+    fn built_in_theme_names_are_not_overridden_by_custom_themes() {
+        let custom = CustomThemeConfig {
+            name: "btop".to_string(),
+            values: [("main_bg", r##""#000000""##)]
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect(),
+        };
+
+        let theme = Theme::from_config_name("btop", &[custom]).unwrap();
+
+        assert_eq!(theme.name, "btop");
+        assert_eq!(theme.main_bg, Theme::btop().main_bg);
+    }
+
+    #[test]
+    fn custom_names_are_available_after_presets() {
+        let custom = CustomThemeConfig {
+            name: "midnight".to_string(),
+            values: Default::default(),
+        };
+
+        let names = available_theme_names(&[custom]);
+
+        assert_eq!(names.first().map(String::as_str), Some("btop"));
+        assert!(names.iter().any(|name| name == "midnight"));
     }
 }


### PR DESCRIPTION
## Summary
- add custom theme sections under `[themes.<name>]` in `~/.config/abtop/config.toml`
- allow custom themes via saved config, `--theme <name>`, and runtime `t` cycling
- document the custom theme schema and add parser/theme tests

## Verification
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- tmux real-use check with temporary XDG_CONFIG_HOME confirmed custom RGB escapes and config overlay showed `Theme midnight`; malformed custom theme ran without panic
- `gitleaks protect --staged --redact` before commit