### PR TITLE
fix: allow terminal drag selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ abtop --once             # Print snapshot and exit
 abtop --json             # Print one JSON snapshot and exit (for scripts/tools)
 abtop --setup            # Install rate limit collection hook
 abtop --theme dracula    # Launch with a specific theme
+abtop --mouse            # Enable mouse click/scroll navigation
 ```
 
 Recommended terminal size: **120x40** or larger. Minimum 80x24 — panels hide gracefully when small.
+Mouse capture is off by default so terminal drag selection and copy keep working. Launch with `--mouse` if you prefer click targets and wheel navigation.
 
 ### Terminal Jump
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ pub fn run() -> io::Result<()> {
 
     let demo_mode = std::env::args().any(|a| a == "--demo");
     let exit_on_jump = std::env::args().any(|a| a == "--exit-on-jump");
+    let mouse_capture = should_enable_mouse_capture(std::env::args());
 
     // --json flag: print a machine-readable JSON snapshot and exit.
     // Single tick, no summary subprocesses. Useful for scripting and as a
@@ -190,7 +191,9 @@ pub fn run() -> io::Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     stdout().execute(EnterAlternateScreen)?;
-    stdout().execute(EnableMouseCapture)?;
+    if mouse_capture {
+        stdout().execute(EnableMouseCapture)?;
+    }
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
 
     let app_result = run_app(
@@ -204,12 +207,24 @@ pub fn run() -> io::Result<()> {
     );
 
     // Always attempt both cleanup steps regardless of app result
-    let r1 = stdout().execute(DisableMouseCapture).map(|_| ());
+    let r1 = if mouse_capture {
+        stdout().execute(DisableMouseCapture).map(|_| ())
+    } else {
+        Ok(())
+    };
     let r2 = disable_raw_mode();
     let r3 = stdout().execute(LeaveAlternateScreen).map(|_| ());
 
     // Return app error first, then cleanup errors
     app_result.and(r1).and(r2).and(r3)
+}
+
+fn should_enable_mouse_capture<I, S>(args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter().any(|a| a.as_ref() == "--mouse")
 }
 
 fn run_app(
@@ -548,5 +563,16 @@ fn fmt_tok(n: u64) -> String {
         format!("{:.1}k", n as f64 / 1_000.0)
     } else {
         format!("{}", n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mouse_capture_is_opt_in() {
+        assert!(!should_enable_mouse_capture(["abtop"]));
+        assert!(should_enable_mouse_capture(["abtop", "--mouse"]));
     }
 }


### PR DESCRIPTION
## Summary
- Leave terminal mouse capture disabled by default so native drag selection and copy work in the TUI.
- Add `--mouse` as an opt-in path for users who want existing click targets and wheel navigation.
- Document the new default and flag in the README.

## Validation
- `git diff --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`