### PR TITLE
fix: remove outdated Claude peak-hours warning

### DIFF
--- a/src/locale.rs
+++ b/src/locale.rs
@@ -145,8 +145,6 @@ static LOCALE_EN: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("footer.quit", "quit");
     m.insert("footer.sessions", "sessions");
     m.insert("footer.auto", "auto");
-    m.insert("footer.peak_hours", "Claude Peak Hours");
-    m.insert("footer.resets_in", "resets in");
     m.insert("footer.esc_clear", "Esc clear, Enter keep");
     m.insert("footer.jump", "jump");
 
@@ -390,8 +388,6 @@ static LOCALE_ZH: LazyLock<std::collections::HashMap<&str, &str>> = LazyLock::ne
     m.insert("footer.quit", "退出");
     m.insert("footer.sessions", "会话");
     m.insert("footer.auto", "自动");
-    m.insert("footer.peak_hours", "Claude 高峰时段");
-    m.insert("footer.resets_in", "重置于");
     m.insert("footer.esc_clear", "Esc 清除，Enter 保留");
     m.insert("footer.jump", "跳转");
 

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -1,7 +1,6 @@
 use crate::app::App;
 use crate::locale::t;
 use crate::theme::Theme;
-use chrono::Timelike;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
@@ -131,28 +130,6 @@ pub(crate) fn draw_footer(f: &mut Frame, app: &App, area: Rect, theme: &Theme) {
                 Style::default().fg(theme.inactive_fg),
             ));
         }
-    }
-
-    // Peak hours warning: US business hours = PT 5am–11am = UTC 12:00–18:00
-    let peak_info = {
-        let now = chrono::Utc::now();
-        let hour = now.hour();
-        if (12..18).contains(&hour) {
-            let mins_left = (18 - hour) * 60 - now.minute();
-            let h = mins_left / 60;
-            let m = mins_left % 60;
-            let peak_label = t("footer.peak_hours");
-            let resets_in = t("footer.resets_in");
-            Some(format!("⚡{} ({} {}h{:02}m)", peak_label, resets_in, h, m))
-        } else {
-            None
-        }
-    };
-    if let Some(ref peak) = peak_info.filter(|_| !compact) {
-        spans.push(Span::styled(
-            format!(" {peak} "),
-            Style::default().fg(theme.warning_fg),
-        ));
     }
 
     let visible_count = app.visible_indices().len();


### PR DESCRIPTION
The footer displayed a Claude peak-hours warning and reset countdown every day from 12:00 to 18:00 UTC, regardless of account or provider state. Anthropic [removed the peak-hours limit reduction for Pro and Max accounts on May 6, 2026](https://www.anthropic.com/news/higher-limits-spacex).

Remove the fixed-time warning, its unused time import, and associated localization keys. Collected quota usage and reset information remain available in the quota panel.

Fixes #173

Validation:
- `cargo test --quiet`: 200 unit tests and 1 integration test passed.
- `cargo clippy -- -D warnings`: passed.
- `rustfmt --edition 2021 --check src/ui/footer.rs src/locale.rs`: passed.
- `git diff --check`: passed.
- `cargo fmt --check`: reports existing formatting differences in unrelated collector files.
